### PR TITLE
clockwork: use non-zero time in NewFakeClock

### DIFF
--- a/clockwork.go
+++ b/clockwork.go
@@ -36,6 +36,9 @@ func NewRealClock() Clock {
 func NewFakeClock() FakeClock {
 	return &fakeClock{
 		l: sync.RWMutex{},
+
+		// use a fixture that does not fulfill Time.IsZero()
+		time: time.Date(1900, time.January, 1, 0, 0, 0, 0, time.UTC),
 	}
 }
 

--- a/clockwork_test.go
+++ b/clockwork_test.go
@@ -1,6 +1,7 @@
 package clockwork
 
 import (
+	"reflect"
 	"testing"
 	"time"
 )
@@ -102,5 +103,18 @@ func TestNotifyBlockers(t *testing.T) {
 	case <-b5.ch:
 	case <-time.After(time.Second):
 		t.Fatalf("timed out waiting for channel close!")
+	}
+}
+
+func TestNewFakeClock(t *testing.T) {
+	fc := NewFakeClock()
+	now := fc.Now()
+	if now.IsZero() {
+		t.Fatalf("fakeClock.Now() fulfills IsZero")
+	}
+
+	now2 := fc.Now()
+	if !reflect.DeepEqual(now, now2) {
+		t.Fatalf("fakeClock.Now() returned different value: want=%#v got=%#v", now, now2)
 	}
 }


### PR DESCRIPTION
The built-in time package provides a function to check whether or not a given Time object represents Time's zero-value: http://golang.org/pkg/time/#Time.IsZero. The current logic in NewFakeClock returns a time that fulfills IsZero. Users of this library that care about the IsZero distinction will get different results when using the fake clock vs the real clock. Simply using a standard time in the past after time zero gets us a static point in time we can use for comparison.
