### PR TITLE
Make default time after the Unix Epoch

### DIFF
--- a/clockwork.go
+++ b/clockwork.go
@@ -36,7 +36,7 @@ func NewRealClock() Clock {
 // FakeClock will be an arbitrary non-zero time.
 func NewFakeClock() FakeClock {
 	// use a fixture that does not fulfill Time.IsZero()
-	return NewFakeClockAt(time.Date(1900, time.January, 1, 0, 0, 0, 0, time.UTC))
+	return NewFakeClockAt(time.Date(1984, time.April, 4, 0, 0, 0, 0, time.UTC))
 }
 
 // NewFakeClock returns a FakeClock initialised at the given time.Time.


### PR DESCRIPTION
Anything before 1970 will give you negative numbers when using the `.Unix()` method and it's a bit weird to see negatives there usually, totally makes tests that use Unix times seem like something is off, if you don't use clockwork much.