### PR TITLE
Only grab a read-lock in Now().

### DIFF
--- a/clockwork.go
+++ b/clockwork.go
@@ -42,7 +42,6 @@ func NewFakeClock() FakeClock {
 // NewFakeClock returns a FakeClock initialised at the given time.Time.
 func NewFakeClockAt(t time.Time) FakeClock {
 	return &fakeClock{
-		l:    sync.RWMutex{},
 		time: t,
 	}
 }
@@ -125,9 +124,10 @@ func (fc *fakeClock) Sleep(d time.Duration) {
 
 // Time returns the current time of the fakeClock
 func (fc *fakeClock) Now() time.Time {
-	fc.l.Lock()
-	defer fc.l.Unlock()
-	return fc.time
+	fc.l.RLock()
+	t := fc.time
+	fc.l.RUnlock()
+	return t
 }
 
 // Advance advances fakeClock to a new point in time, ensuring channels from any


### PR DESCRIPTION
I can see two possible stances here:

1. You consider the `fakeClock` non-performance sensitive test code, in which case we might just turn the `RWMutex` into a plain `Mutex`.
2. You want to keep a `RWMutex` so that multiple callers can call `Now()` with less friction, in which case we should use `RLock()` / `RUnlock()`.

I initially went with approach 1, somehow changed my mind for 2, but could be convinced either way.