### PR TITLE
Add clock.Since() function to replicate time.Since() behavior

### DIFF
--- a/clockwork.go
+++ b/clockwork.go
@@ -11,6 +11,7 @@ type Clock interface {
 	After(d time.Duration) <-chan time.Time
 	Sleep(d time.Duration)
 	Now() time.Time
+	Since(t time.Time) time.Duration
 }
 
 // FakeClock provides an interface for a clock which can be
@@ -58,6 +59,10 @@ func (rc *realClock) Sleep(d time.Duration) {
 
 func (rc *realClock) Now() time.Time {
 	return time.Now()
+}
+
+func (rc *realClock) Since(t time.Time) time.Duration {
+	return rc.Now().Sub(t)
 }
 
 type fakeClock struct {
@@ -128,6 +133,11 @@ func (fc *fakeClock) Now() time.Time {
 	t := fc.time
 	fc.l.RUnlock()
 	return t
+}
+
+// Since returns the duration that has passed since the given time on the fakeClock
+func (fc *fakeClock) Since(t time.Time) time.Duration {
+	return fc.Now().Sub(t)
 }
 
 // Advance advances fakeClock to a new point in time, ensuring channels from any

--- a/clockwork_test.go
+++ b/clockwork_test.go
@@ -127,3 +127,13 @@ func TestNewFakeClockAt(t *testing.T) {
 		t.Fatalf("fakeClock.Now() returned unexpected non-initialised value: want=%#v, got %#v", t1, now)
 	}
 }
+
+func TestFakeClockSince(t *testing.T) {
+	fc := NewFakeClock()
+	now := fc.Now()
+	elapsedTime := time.Second
+	fc.Advance(elapsedTime)
+	if fc.Since(now) != elapsedTime {
+		t.Fatalf("fakeClock.Since() returned unexpected duration, got: %d, want: %d", fc.Since(now), elapsedTime)
+	}
+}


### PR DESCRIPTION
This is the only function I came across so far where I couldn't simply replace time.X() with clock.X() but had to use clock.Now().Sub(...) instead.