### PR TITLE
Add support for fake tickers

### DIFF
--- a/clockwork.go
+++ b/clockwork.go
@@ -12,6 +12,7 @@ type Clock interface {
 	Sleep(d time.Duration)
 	Now() time.Time
 	Since(t time.Time) time.Duration
+	NewTicker(d time.Duration) Ticker
 }
 
 // FakeClock provides an interface for a clock which can be
@@ -63,6 +64,10 @@ func (rc *realClock) Now() time.Time {
 
 func (rc *realClock) Since(t time.Time) time.Duration {
 	return rc.Now().Sub(t)
+}
+
+func (rc *realClock) NewTicker(d time.Duration) Ticker {
+	return &realTicker{*time.NewTicker(d)}
 }
 
 type fakeClock struct {
@@ -138,6 +143,17 @@ func (fc *fakeClock) Now() time.Time {
 // Since returns the duration that has passed since the given time on the fakeClock
 func (fc *fakeClock) Since(t time.Time) time.Duration {
 	return fc.Now().Sub(t)
+}
+
+func (fc *fakeClock) NewTicker(d time.Duration) Ticker {
+	ft := &fakeTicker{
+		c:      make(chan time.Time, 1),
+		stop:   make(chan bool, 1),
+		clock:  fc,
+		period: d,
+	}
+	go ft.tick()
+	return ft
 }
 
 // Advance advances fakeClock to a new point in time, ensuring channels from any

--- a/clockwork.go
+++ b/clockwork.go
@@ -67,7 +67,7 @@ func (rc *realClock) Since(t time.Time) time.Duration {
 }
 
 func (rc *realClock) NewTicker(d time.Duration) Ticker {
-	return &realTicker{*time.NewTicker(d)}
+	return &realTicker{time.NewTicker(d)}
 }
 
 type fakeClock struct {

--- a/ticker.go
+++ b/ticker.go
@@ -1,0 +1,66 @@
+package clockwork
+
+import (
+	"time"
+)
+
+// Ticker provides an interface which can be used instead of directly
+// using the ticker within the time module. The real-time ticker t
+// provides tickets through t.C which becomes now t.Chan() to make
+// this channel requirement definable in this interface.
+type Ticker interface {
+	Chan() <-chan time.Time
+	Stop()
+}
+
+type realTicker struct{ time.Ticker }
+
+func (rt *realTicker) Chan() <-chan time.Time {
+	return rt.C
+}
+
+type fakeTicker struct {
+	c      chan time.Time
+	stop   chan bool
+	clock  FakeClock
+	period time.Duration
+}
+
+func (ft *fakeTicker) Chan() <-chan time.Time {
+	return ft.c
+}
+
+func (ft *fakeTicker) Stop() {
+	ft.stop <- true
+}
+
+// tick sends the tick time to the ticker channel after every period.
+// Tick events are discarded if the underlying ticker channel does
+// not have enough capacity.
+func (ft *fakeTicker) tick() {
+	tick := ft.clock.Now()
+	for {
+		tick = tick.Add(ft.period)
+		remaining := tick.Sub(ft.clock.Now())
+		if remaining <= 0 {
+			// The tick should have already happened. This can happen when
+			// Advance() is called on the fake clock with a duration larger
+			// than this ticker's period.
+			select {
+			case ft.c <- tick:
+			default:
+			}
+			continue
+		}
+
+		select {
+		case <-ft.stop:
+			return
+		case <-ft.clock.After(remaining):
+			select {
+			case ft.c <- tick:
+			default:
+			}
+		}
+	}
+}

--- a/ticker.go
+++ b/ticker.go
@@ -13,7 +13,7 @@ type Ticker interface {
 	Stop()
 }
 
-type realTicker struct{ time.Ticker }
+type realTicker struct{ *time.Ticker }
 
 func (rt *realTicker) Chan() <-chan time.Time {
 	return rt.C

--- a/ticker.go
+++ b/ticker.go
@@ -6,7 +6,7 @@ import (
 
 // Ticker provides an interface which can be used instead of directly
 // using the ticker within the time module. The real-time ticker t
-// provides tickets through t.C which becomes now t.Chan() to make
+// provides ticks through t.C which becomes now t.Chan() to make
 // this channel requirement definable in this interface.
 type Ticker interface {
 	Chan() <-chan time.Time

--- a/ticker_test.go
+++ b/ticker_test.go
@@ -1,0 +1,58 @@
+package clockwork
+
+import (
+	"testing"
+)
+
+func TestFakeTickerStop(t *testing.T) {
+	fc := &fakeClock{}
+
+	ft := fc.NewTicker(1)
+	ft.Stop()
+	select {
+	case <-ft.Chan():
+		t.Errorf("received unexpected tick!")
+	default:
+	}
+}
+
+func TestFakeTickerTick(t *testing.T) {
+	fc := &fakeClock{}
+	now := fc.Now()
+
+	// The tick at now.Add(2) should not get through since we advance time by
+	// two units below and the channel can hold at most one tick until it's
+	// consumed.
+	first := now.Add(1)
+	second := now.Add(3)
+
+	// We wrap the Advance() calls with blockers to make sure that the ticker
+	// can go to sleep and produce ticks without time passing in parallel.
+	ft := fc.NewTicker(1)
+	fc.BlockUntil(1)
+	fc.Advance(2)
+	fc.BlockUntil(1)
+
+	select {
+	case tick := <-ft.Chan():
+		if tick != first {
+			t.Errorf("wrong tick time, got: %d, want: %d", tick, first)
+		}
+	default:
+		t.Errorf("expected tick!")
+	}
+
+	// Advance by one more unit, we should get another tick now.
+	fc.Advance(1)
+	fc.BlockUntil(1)
+
+	select {
+	case tick := <-ft.Chan():
+		if tick != second {
+			t.Errorf("wrong tick time, got: %d, want: %d", tick, second)
+		}
+	default:
+		t.Errorf("expected tick!")
+	}
+	ft.Stop()
+}

--- a/ticker_test.go
+++ b/ticker_test.go
@@ -36,7 +36,7 @@ func TestFakeTickerTick(t *testing.T) {
 	select {
 	case tick := <-ft.Chan():
 		if tick != first {
-			t.Errorf("wrong tick time, got: %d, want: %d", tick, first)
+			t.Errorf("wrong tick time, got: %v, want: %v", tick, first)
 		}
 	default:
 		t.Errorf("expected tick!")
@@ -49,7 +49,7 @@ func TestFakeTickerTick(t *testing.T) {
 	select {
 	case tick := <-ft.Chan():
 		if tick != second {
-			t.Errorf("wrong tick time, got: %d, want: %d", tick, second)
+			t.Errorf("wrong tick time, got: %v, want: %v", tick, second)
 		}
 	default:
 		t.Errorf("expected tick!")


### PR DESCRIPTION
I spend a little time on extending your library to add support for fake tickers.
Currently this requires surrounding the Advance() calls with BlockUntil() to make sure that the ticker can go to sleep before Advance() is called and afterwards wake up before we start consuming ticks.
Let me know what you think.
