### PR TITLE
Add a new interface method: AfterTime

### DIFF
--- a/clockwork_test.go
+++ b/clockwork_test.go
@@ -137,3 +137,75 @@ func TestFakeClockSince(t *testing.T) {
 		t.Fatalf("fakeClock.Since() returned unexpected duration, got: %d, want: %d", fc.Since(now), elapsedTime)
 	}
 }
+
+func TestFakeClockAfterTime(t *testing.T) {
+	fc := &fakeClock{}
+
+	add := func(d int) time.Time {
+		return fc.Now().Add(time.Duration(d))
+	}
+
+	zero := fc.AfterTime(add(0))
+	select {
+	case <-zero:
+	default:
+		t.Errorf("zero did not return!")
+	}
+	one := fc.AfterTime(add(1))
+	two := fc.AfterTime(add(2))
+	six := fc.AfterTime(add(6))
+	ten := fc.AfterTime(add(10))
+	fc.Advance(1)
+	select {
+	case <-one:
+	default:
+		t.Errorf("one did not return!")
+	}
+	select {
+	case <-two:
+		t.Errorf("two returned prematurely!")
+	case <-six:
+		t.Errorf("six returned prematurely!")
+	case <-ten:
+		t.Errorf("ten returned prematurely!")
+	default:
+	}
+	fc.Advance(1)
+	select {
+	case <-two:
+	default:
+		t.Errorf("two did not return!")
+	}
+	select {
+	case <-six:
+		t.Errorf("six returned prematurely!")
+	case <-ten:
+		t.Errorf("ten returned prematurely!")
+	default:
+	}
+	fc.Advance(1)
+	select {
+	case <-six:
+		t.Errorf("six returned prematurely!")
+	case <-ten:
+		t.Errorf("ten returned prematurely!")
+	default:
+	}
+	fc.Advance(3)
+	select {
+	case <-six:
+	default:
+		t.Errorf("six did not return!")
+	}
+	select {
+	case <-ten:
+		t.Errorf("ten returned prematurely!")
+	default:
+	}
+	fc.Advance(100)
+	select {
+	case <-ten:
+	default:
+		t.Errorf("ten did not return!")
+	}
+}


### PR DESCRIPTION
Without this iterface, there is an unresolvable race condition with `After` vs. `Advance`. In one go routine, you might:

```go
    deadline := /* some deadline in the future */;
    wait := deadline.Sub(fc.Now());
    select {
      case <-fc.After(wait):
    }
```

And in another, you might:

```go
   fc.Advance(3)
```

The problem is that two go-routines might interleave arbitrarily. The solution is to compute the deadline and to call `After` atomically, but you can't do that without sleeping on a lock. I believe `BlockUntil` was partially invented to handle this problem, so that you could call `Advance` only after you know that the other go-routine was selecting on the `After`. But it can be quite challenging to figure out which parameter to pass to `BlockUntil`, especially if your code is happy to let old `After` calls just dangle until they expire (which otherwise isn't a problem).

The solution is just to add a new interface method, which is to write to a channel after a given time has been surpassed. This feature was basically available internally, but this PR makes it available
publicly.