### PR TITLE
README: Fix "Faking time" Golang playground anchor

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,4 +66,4 @@ See [example_test.go](example_test.go) for a full example.
 
 # Credits
 
-clockwork is inspired by @wickman's [threaded fake clock](https://gist.github.com/wickman/3840816), and the [Golang playground](http://blog.golang.org/playground#Faking time)
+clockwork is inspired by @wickman's [threaded fake clock](https://gist.github.com/wickman/3840816), and the [Golang playground](https://blog.golang.org/playground#TOC_3.1.)


### PR DESCRIPTION
I'm not sure when this changed, but the current Golang page has a TOC anchor:

```console
$ curl -s https://blog.golang.org/playground | grep 'Faking time'
  <h4 id="TOC_3.1.">Faking time</h4>
```

The old "Faking time" anchor is from e61ab69f (2014), and at least GitHub's Markdown render took issue with the literal space there (spaces should be [percent-encoded for fragments][1]).

[1]: https://tools.ietf.org/html/rfc3986#section-3.5