### PR TITLE
FakeClock.After should short-circuit for negative inputs

### DIFF
--- a/clockwork.go
+++ b/clockwork.go
@@ -97,7 +97,7 @@ func (fc *fakeClock) After(d time.Duration) <-chan time.Time {
 	defer fc.l.Unlock()
 	now := fc.time
 	done := make(chan time.Time, 1)
-	if d.Nanoseconds() == 0 {
+	if d.Nanoseconds() <= 0 {
 		// special case - trigger immediately
 		done <- now
 	} else {

--- a/clockwork_test.go
+++ b/clockwork_test.go
@@ -9,6 +9,13 @@ import (
 func TestFakeClockAfter(t *testing.T) {
 	fc := &fakeClock{}
 
+	neg := fc.After(-1)
+	select {
+	case <-neg:
+	default:
+		t.Errorf("negative did not return!")
+	}
+
 	zero := fc.After(0)
 	select {
 	case <-zero:


### PR DESCRIPTION
FakeClock.After currently does not short-circuit for negative inputs the way that the `time` package does.

Fixes #19 
Fixes #21