### PR TITLE
feat: Add context helpers to package.

### DIFF
--- a/clockwork.go
+++ b/clockwork.go
@@ -1,6 +1,7 @@
 package clockwork
 
 import (
+	"context"
 	"sync"
 	"time"
 )
@@ -25,6 +26,8 @@ type FakeClock interface {
 	// BlockUntil will block until the FakeClock has the given number of
 	// sleepers (callers of Sleep or After)
 	BlockUntil(n int)
+	// AddTo creates a derived context that references the clock.
+	AddTo(ctx context.Context) context.Context
 }
 
 // NewRealClock returns a Clock which simply delegates calls to the actual time
@@ -192,4 +195,9 @@ func (fc *fakeClock) BlockUntil(n int) {
 	fc.blockers = append(fc.blockers, b)
 	fc.l.Unlock()
 	<-b.ch
+}
+
+// AddTo creates a derived context that references the clock.
+func (fc *fakeClock) AddTo(ctx context.Context) context.Context {
+	return AddTo(ctx, fc)
 }

--- a/clockwork.go
+++ b/clockwork.go
@@ -1,7 +1,6 @@
 package clockwork
 
 import (
-	"context"
 	"sync"
 	"time"
 )
@@ -26,8 +25,6 @@ type FakeClock interface {
 	// BlockUntil will block until the FakeClock has the given number of
 	// sleepers (callers of Sleep or After)
 	BlockUntil(n int)
-	// AddTo creates a derived context that references the clock.
-	AddTo(ctx context.Context) context.Context
 }
 
 // NewRealClock returns a Clock which simply delegates calls to the actual time
@@ -195,9 +192,4 @@ func (fc *fakeClock) BlockUntil(n int) {
 	fc.blockers = append(fc.blockers, b)
 	fc.l.Unlock()
 	<-b.ch
-}
-
-// AddTo creates a derived context that references the clock.
-func (fc *fakeClock) AddTo(ctx context.Context) context.Context {
-	return AddTo(ctx, fc)
 }

--- a/context.go
+++ b/context.go
@@ -11,13 +11,13 @@ type contextKey string
 // keyClock provides a clock for injecting during tests. If absent, a real clock should be used.
 var keyClock = contextKey("clock") // clockwork.Clock
 
-// AddTo creates a derived context that references the specified clock.
-func AddTo(ctx context.Context, clock Clock) context.Context {
+// AddToContext creates a derived context that references the specified clock.
+func AddToContext(ctx context.Context, clock Clock) context.Context {
 	return context.WithValue(ctx, keyClock, clock)
 }
 
-// From extracts a clock from the context. If not present, a real clock is returned.
-func From(ctx context.Context) Clock {
+// FromContext extracts a clock from the context. If not present, a real clock is returned.
+func FromContext(ctx context.Context) Clock {
 	if clock, ok := ctx.Value(keyClock).(Clock); ok {
 		return clock
 	}

--- a/context.go
+++ b/context.go
@@ -1,0 +1,25 @@
+package clockwork
+
+import (
+	"context"
+)
+
+// contextKey is private to this package so we can ensure uniqueness here. This
+// type identifies context values provided by this package.
+type contextKey string
+
+// keyClock provides a clock for injecting during tests. If absent, a real clock should be used.
+var keyClock = contextKey("clock") // clockwork.Clock
+
+// AddTo creates a derived context that references the specified clock.
+func AddTo(ctx context.Context, clock Clock) context.Context {
+	return context.WithValue(ctx, keyClock, clock)
+}
+
+// From extracts a clock from the context. If not present, a real clock is returned.
+func From(ctx context.Context) Clock {
+	if clock, ok := ctx.Value(keyClock).(Clock); ok {
+		return clock
+	}
+	return NewRealClock()
+}

--- a/context_test.go
+++ b/context_test.go
@@ -1,0 +1,26 @@
+package clockwork
+
+import (
+	"context"
+	"reflect"
+	"testing"
+)
+
+func TestContextOps(t *testing.T) {
+	ctx := context.Background()
+	assertIsType(t, NewRealClock(), From(ctx))
+
+	ctx = AddTo(ctx, NewFakeClock())
+	assertIsType(t, NewFakeClock(), From(ctx))
+
+	ctx = AddTo(ctx, NewRealClock())
+	assertIsType(t, NewRealClock(), From(ctx))
+}
+
+func assertIsType(t *testing.T, expectedType interface{}, object interface{}) {
+	t.Helper()
+
+	if reflect.TypeOf(object) != reflect.TypeOf(expectedType) {
+		t.Fatalf("Object expected to be of type %v, but was %v", reflect.TypeOf(expectedType), reflect.TypeOf(object))
+	}
+}

--- a/context_test.go
+++ b/context_test.go
@@ -8,13 +8,13 @@ import (
 
 func TestContextOps(t *testing.T) {
 	ctx := context.Background()
-	assertIsType(t, NewRealClock(), From(ctx))
+	assertIsType(t, NewRealClock(), FromContext(ctx))
 
-	ctx = AddTo(ctx, NewFakeClock())
-	assertIsType(t, NewFakeClock(), From(ctx))
+	ctx = AddToContext(ctx, NewFakeClock())
+	assertIsType(t, NewFakeClock(), FromContext(ctx))
 
-	ctx = AddTo(ctx, NewRealClock())
-	assertIsType(t, NewRealClock(), From(ctx))
+	ctx = AddToContext(ctx, NewRealClock())
+	assertIsType(t, NewRealClock(), FromContext(ctx))
 }
 
 func assertIsType(t *testing.T, expectedType interface{}, object interface{}) {


### PR DESCRIPTION
This change adds new methods .AddTo() and .From() to assist with
threading clocks through code paths via context. Enables
simple fake clock usage in test where needed.

Closes #32