### PR TITLE
Refactor to avoid channels and goroutines

### DIFF
--- a/clockwork_test.go
+++ b/clockwork_test.go
@@ -168,3 +168,23 @@ func TestTwoBlockersOneBlock(t *testing.T) {
 	ft1.Stop()
 	ft2.Stop()
 }
+
+func TestAfterDeliveryInOrder(t *testing.T) {
+	fc := &fakeClock{}
+	for i := 0; i < 1000; i++ {
+		three := fc.After(3 * time.Second)
+		for j := 0; j < 100; j++ {
+			fc.After(1 * time.Second)
+		}
+		two := fc.After(2 * time.Second)
+		go func() {
+			fc.Advance(5 * time.Second)
+		}()
+		<-three
+		select {
+		case <-two:
+		default:
+			t.Fatalf("Signals from After delivered out of order")
+		}
+	}
+}

--- a/ticker.go
+++ b/ticker.go
@@ -15,58 +15,15 @@ type Ticker interface {
 
 type realTicker struct{ *time.Ticker }
 
-func (rt *realTicker) Chan() <-chan time.Time {
+func (rt realTicker) Chan() <-chan time.Time {
 	return rt.C
 }
 
 type fakeTicker struct {
-	c      chan time.Time
-	stop   chan bool
-	clock  FakeClock
-	period time.Duration
-}
-
-func (ft *fakeTicker) Chan() <-chan time.Time {
-	return ft.c
+	fakeTimer
 }
 
 func (ft *fakeTicker) Stop() {
-	ft.stop <- true
-}
-
-// runTickThread initializes a background goroutine to send the tick time to the ticker channel
-// after every period. Tick events are discarded if the underlying ticker channel does not have
-// enough capacity.
-func (ft *fakeTicker) runTickThread() {
-	nextTick := ft.clock.Now().Add(ft.period)
-	next := ft.clock.After(ft.period)
-	go func() {
-		for {
-			select {
-			case <-ft.stop:
-				return
-			case <-next:
-				// We send the time that the tick was supposed to occur at.
-				tick := nextTick
-				// Before sending the tick, we'll compute the next tick time and star the clock.After call.
-				now := ft.clock.Now()
-				// First, figure out how many periods there have been between "now" and the time we were
-				// supposed to have trigged, then advance over all of those.
-				skipTicks := (now.Sub(tick) + ft.period - 1) / ft.period
-				nextTick = nextTick.Add(skipTicks * ft.period)
-				// Now, keep advancing until we are past now. This should happen at most once.
-				for !nextTick.After(now) {
-					nextTick = nextTick.Add(ft.period)
-				}
-				// Figure out how long between now and the next scheduled tick, then wait that long.
-				remaining := nextTick.Sub(now)
-				next = ft.clock.After(remaining)
-				// Finally, we can actually send the tick.
-				select {
-				case ft.c <- tick:
-				default:
-				}
-			}
-		}
-	}()
+	// Ignore returned bool to make signature match.
+	ft.fakeTimer.Stop()
 }

--- a/timer.go
+++ b/timer.go
@@ -83,6 +83,6 @@ func (f *fakeTimer) resetImpl(d time.Duration) {
 		f.clock.sleepers = append(f.clock.sleepers, f)
 		sort.Sort(f.clock.sleepers)
 		// and notify any blockers
-		f.clock.blockers = notifyBlockers(f.clock.blockers, len(f.clock.sleepers))
+		f.clock.notifyBlockers()
 	}
 }


### PR DESCRIPTION
In terms of features, the addition of `AfterFunc` is the main benefit here. Otherwise it addresses a number of bugs, mainly around out-of-order or duplicate delivery of events, as exposed by the various tests added by these changes.

These changes merge the `sleeper` and the `fakeTimer` task. Now a `fakeTimer` object is used to represent any future event on the timeline of a given fake clock. When the time advances to that point, a callback on the `fakeTimer` gets called. This makes sending to a channel only one of many possible responses on expiry. Not using channels, but instead an internal callback that gets called with the clock's lock held, allows using the timer far more flexible. It is now also the basis of ticker and of the `After` method. This change in general will do more things while holding the clock's lock, leading to more consistent behavior and less risk of data races.

Basing `After` on `Timer` instead of the other way round also allows clearing the future events when timers get stopped or reset. This in turn helps `BlockUntil` actually track active blockers, ignoring obsolete ones that used to exist in the past.

This fixes https://github.com/jonboulle/clockwork/issues/42.