### PR TITLE
Make FakeTicker synchronous

### DIFF
--- a/clockwork.go
+++ b/clockwork.go
@@ -154,7 +154,7 @@ func (fc *fakeClock) Since(t time.Time) time.Duration {
 // Advance have moved the clock passed the given duration
 func (fc *fakeClock) NewTicker(d time.Duration) Ticker {
 	ft := &fakeTicker{
-		c:      make(chan time.Time, 1),
+		c:      make(chan time.Time),
 		stop:   make(chan bool, 1),
 		clock:  fc,
 		period: d,

--- a/ticker.go
+++ b/ticker.go
@@ -62,10 +62,7 @@ func (ft *fakeTicker) runTickThread() {
 				remaining := nextTick.Sub(now)
 				next = ft.clock.After(remaining)
 				// Finally, we can actually send the tick.
-				select {
-				case ft.c <- tick:
-				default:
-				}
+				ft.c <- tick
 			}
 		}
 	}()


### PR DESCRIPTION
I'm trying to use FakeTicker to test production code that uses clockwork.Ticker. I found that my FakeTicker would "race ahead", since it doesn't block on ft.c being available to receive a tick.

I make it synchronous, and add a test case showing the behavior.