### PR TITLE
Move most lock logic to clockwork.go.

### DIFF
--- a/clockwork_test.go
+++ b/clockwork_test.go
@@ -7,6 +7,7 @@ import (
 )
 
 func TestFakeClockAfter(t *testing.T) {
+	t.Parallel()
 	fc := &fakeClock{}
 
 	neg := fc.After(-1)
@@ -82,6 +83,7 @@ func TestFakeClockAfter(t *testing.T) {
 }
 
 func TestNotifyBlockers(t *testing.T) {
+	t.Parallel()
 	b1 := &blocker{1, make(chan struct{})}
 	b2 := &blocker{2, make(chan struct{})}
 	b3 := &blocker{5, make(chan struct{})}
@@ -89,7 +91,7 @@ func TestNotifyBlockers(t *testing.T) {
 	b5 := &blocker{10, make(chan struct{})}
 	fc := fakeClock{
 		blockers: []*blocker{b1, b2, b3, b4, b5},
-		sleepers: sleepers{nil, nil},
+		waiters:  []expirer{nil, nil},
 	}
 	fc.notifyBlockers()
 	if n := len(fc.blockers); n != 3 {
@@ -105,8 +107,8 @@ func TestNotifyBlockers(t *testing.T) {
 	case <-time.After(time.Second):
 		t.Fatalf("timed out waiting for channel close!")
 	}
-	for len(fc.sleepers) < 10 {
-		fc.sleepers = append(fc.sleepers, nil)
+	for len(fc.waiters) < 10 {
+		fc.waiters = append(fc.waiters, nil)
 	}
 	fc.notifyBlockers()
 	if n := len(fc.blockers); n != 0 {
@@ -130,6 +132,7 @@ func TestNotifyBlockers(t *testing.T) {
 }
 
 func TestNewFakeClock(t *testing.T) {
+	t.Parallel()
 	fc := NewFakeClock()
 	now := fc.Now()
 	if now.IsZero() {
@@ -143,6 +146,7 @@ func TestNewFakeClock(t *testing.T) {
 }
 
 func TestNewFakeClockAt(t *testing.T) {
+	t.Parallel()
 	t1 := time.Date(1999, time.February, 3, 4, 5, 6, 7, time.UTC)
 	fc := NewFakeClockAt(t1)
 	now := fc.Now()
@@ -152,6 +156,7 @@ func TestNewFakeClockAt(t *testing.T) {
 }
 
 func TestFakeClockSince(t *testing.T) {
+	t.Parallel()
 	fc := NewFakeClock()
 	now := fc.Now()
 	elapsedTime := time.Second
@@ -164,6 +169,7 @@ func TestFakeClockSince(t *testing.T) {
 // This used to result in a deadlock.
 // https://github.com/jonboulle/clockwork/issues/35
 func TestTwoBlockersOneBlock(t *testing.T) {
+	t.Parallel()
 	fc := &fakeClock{}
 
 	ft1 := fc.NewTicker(time.Second)
@@ -176,6 +182,7 @@ func TestTwoBlockersOneBlock(t *testing.T) {
 }
 
 func TestAfterDeliveryInOrder(t *testing.T) {
+	t.Parallel()
 	fc := &fakeClock{}
 	for i := 0; i < 1000; i++ {
 		three := fc.After(3 * time.Second)
@@ -193,4 +200,16 @@ func TestAfterDeliveryInOrder(t *testing.T) {
 			t.Fatalf("Signals from After delivered out of order")
 		}
 	}
+}
+
+// TestFakeClockRace detects data races in fakeClock when invoked with run using `go -race ...`.
+// There are no failure conditions when invoked without the -race flag.
+func TestFakeClockRace(t *testing.T) {
+	t.Parallel()
+	fc := &fakeClock{}
+	d := time.Second
+	go func() { fc.Advance(d) }()
+	go func() { fc.NewTicker(d) }()
+	go func() { fc.NewTimer(d) }()
+	go func() { fc.Sleep(d) }()
 }

--- a/context_test.go
+++ b/context_test.go
@@ -7,6 +7,7 @@ import (
 )
 
 func TestContextOps(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	assertIsType(t, NewRealClock(), FromContext(ctx))
 
@@ -17,7 +18,7 @@ func TestContextOps(t *testing.T) {
 	assertIsType(t, NewRealClock(), FromContext(ctx))
 }
 
-func assertIsType(t *testing.T, expectedType interface{}, object interface{}) {
+func assertIsType(t *testing.T, expectedType, object any) {
 	t.Helper()
 
 	if reflect.TypeOf(object) != reflect.TypeOf(expectedType) {

--- a/example_test.go
+++ b/example_test.go
@@ -32,18 +32,18 @@ func TestMyFunc(t *testing.T) {
 		wg.Done()
 	}()
 
-	// Wait until myFunc is actually sleeping on the clock
+	// Wait until myFunc is actually sleeping on the clock.
 	c.BlockUntil(1)
 
-	// Assert the initial state
+	// Assert the initial state.
 	assertState(t, i, 0)
 
-	// Now advance the clock forward in time
+	// Now advance the clock forward in time.
 	c.Advance(1 * time.Hour)
 
-	// Wait until the function completes
+	// Wait until the function completes.
 	wg.Wait()
 
-	// Assert the final state
+	// Assert the final state.
 	assertState(t, i, 1)
 }

--- a/ticker.go
+++ b/ticker.go
@@ -1,29 +1,51 @@
 package clockwork
 
-import (
-	"time"
-)
+import "time"
 
-// Ticker provides an interface which can be used instead of directly
-// using the ticker within the time module. The real-time ticker t
-// provides ticks through t.C which becomes now t.Chan() to make
-// this channel requirement definable in this interface.
+// Ticker provides an interface which can be used instead of directly using
+// [time.Ticker]. The real-time ticker t provides ticks through t.C which
+// becomes t.Chan() to make this channel requirement definable in this
+// interface.
 type Ticker interface {
 	Chan() <-chan time.Time
+	Reset(d time.Duration)
 	Stop()
 }
 
 type realTicker struct{ *time.Ticker }
 
-func (rt realTicker) Chan() <-chan time.Time {
-	return rt.C
+func (r realTicker) Chan() <-chan time.Time {
+	return r.C
 }
 
 type fakeTicker struct {
-	fakeTimer
+	firer
+
+	// reset and stop provide the implmenetation of the respective exported
+	// functions.
+	reset func(d time.Duration)
+	stop  func()
+
+	// The duration of the ticker.
+	d time.Duration
 }
 
-func (ft *fakeTicker) Stop() {
-	// Ignore returned bool to make signature match.
-	ft.fakeTimer.Stop()
+func (f *fakeTicker) Reset(d time.Duration) {
+	if d <= 0 {
+		panic("non-positive interval for Ticker.Reset")
+	}
+	f.reset(d)
+}
+
+func (f *fakeTicker) Stop() {
+	f.stop()
+}
+
+func (f *fakeTicker) expire(now time.Time) *time.Duration {
+	// Never block on expiration.
+	select {
+	case f.c <- now:
+	default:
+	}
+	return &f.d
 }

--- a/ticker_test.go
+++ b/ticker_test.go
@@ -7,6 +7,7 @@ import (
 )
 
 func TestFakeTickerStop(t *testing.T) {
+	t.Parallel()
 	fc := &fakeClock{}
 
 	ft := fc.NewTicker(1)
@@ -19,6 +20,7 @@ func TestFakeTickerStop(t *testing.T) {
 }
 
 func TestFakeTickerTick(t *testing.T) {
+	t.Parallel()
 	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
 	defer cancel()
 
@@ -63,10 +65,12 @@ func TestFakeTickerTick(t *testing.T) {
 }
 
 func TestFakeTicker_Race(t *testing.T) {
+	t.Parallel()
 	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
 	defer cancel()
 
 	fc := NewFakeClock()
+
 	tickTime := 1 * time.Millisecond
 	ticker := fc.NewTicker(tickTime)
 	defer ticker.Stop()
@@ -75,12 +79,14 @@ func TestFakeTicker_Race(t *testing.T) {
 
 	select {
 	case <-ticker.Chan():
+	// Pass
 	case <-ctx.Done():
 		t.Fatalf("Ticker didn't detect the clock advance!")
 	}
 }
 
 func TestFakeTicker_Race2(t *testing.T) {
+	t.Parallel()
 	fc := NewFakeClock()
 	ft := fc.NewTicker(5 * time.Second)
 	for i := 0; i < 100; i++ {
@@ -91,13 +97,14 @@ func TestFakeTicker_Race2(t *testing.T) {
 }
 
 func TestFakeTicker_DeliveryOrder(t *testing.T) {
+	t.Parallel()
 	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
 	defer cancel()
 	fc := NewFakeClock()
 	ticker := fc.NewTicker(2 * time.Second).Chan()
 	timer := fc.NewTimer(5 * time.Second).Chan()
 	go func() {
-		for j := 0; j < 10; j++ {
+		for j := 0; j < 100; j++ {
 			fc.BlockUntil(1)
 			fc.Advance(1 * time.Second)
 		}

--- a/timer.go
+++ b/timer.go
@@ -1,88 +1,53 @@
 package clockwork
 
-import (
-	"sort"
-	"time"
-)
+import "time"
 
-// Timer provides an interface which can be used instead of directly
-// using the timer within the time module. The real-time timer t
-// provides events through t.C which becomes now t.Chan() to make
-// this channel requirement definable in this interface.
+// Timer provides an interface which can be used instead of directly using
+// [time.Timer]. The real-time timer t provides events through t.C which becomes
+// t.Chan() to make this channel requirement definable in this interface.
 type Timer interface {
 	Chan() <-chan time.Time
 	Reset(d time.Duration) bool
 	Stop() bool
 }
 
-type realTimer struct {
-	*time.Timer
-}
+type realTimer struct{ *time.Timer }
 
 func (r realTimer) Chan() <-chan time.Time {
 	return r.C
 }
 
 type fakeTimer struct {
-	// The channel associated with this timer. Only relevant for timers that
-	// originate from NewTimer or similar, i.e. not for AfterFunc or other
-	// internal usage.
-	c chan time.Time
+	firer
 
-	// The fake clock driving events for this timer.
-	clock *fakeClock
+	// reset and stop provide the implmenetation of the respective exported
+	// functions.
+	reset func(d time.Duration) bool
+	stop  func() bool
 
-	// The time when the timer expires. Only meaningful if the timer is currently
-	// one of the fake clock's sleepers.
-	until time.Time
-
-	// callback will get called synchronously with the lock of the clock being
-	// held. It receives the time at which the timer expired.
-	callback func(time.Time)
-}
-
-func (f *fakeTimer) Chan() <-chan time.Time {
-	return f.c
-}
-
-func (f *fakeTimer) Stop() bool {
-	f.clock.l.Lock()
-	defer f.clock.l.Unlock()
-	return f.stopImpl()
-}
-
-func (f *fakeTimer) stopImpl() bool {
-	for i, t := range f.clock.sleepers {
-		if t == f {
-			// Remove element, maintaining order.
-			copy(f.clock.sleepers[i:], f.clock.sleepers[i+1:])
-			f.clock.sleepers[len(f.clock.sleepers)-1] = nil
-			f.clock.sleepers = f.clock.sleepers[:len(f.clock.sleepers)-1]
-			return true
-		}
-	}
-	return false
+	// If present when the timer fires, the timer calls afterFunc in its own
+	// goroutine rather than sending the time on Chan().
+	afterFunc func()
 }
 
 func (f *fakeTimer) Reset(d time.Duration) bool {
-	f.clock.l.Lock()
-	defer f.clock.l.Unlock()
-	stopped := f.stopImpl()
-	f.resetImpl(d)
-	return stopped
+	return f.reset(d)
 }
 
-func (f *fakeTimer) resetImpl(d time.Duration) {
-	now := f.clock.time
-	if d.Nanoseconds() <= 0 {
-		// special case - trigger immediately
-		f.callback(now)
-	} else {
-		// otherwise, add to the set of sleepers
-		f.until = f.clock.time.Add(d)
-		f.clock.sleepers = append(f.clock.sleepers, f)
-		sort.Sort(f.clock.sleepers)
-		// and notify any blockers
-		f.clock.notifyBlockers()
+func (f *fakeTimer) Stop() bool {
+	return f.stop()
+}
+
+func (f *fakeTimer) expire(now time.Time) *time.Duration {
+	if f.afterFunc != nil {
+		go f.afterFunc()
+		return nil
 	}
+
+	// Never block on expiration.
+	select {
+	case f.c <- now:
+	default:
+	}
+	return nil
 }


### PR DESCRIPTION
This uses longer timeouts throughout ticker_test.go to prevent flaky failures in slower runs.

It uses a timeout of 1 minute, which seems more than reasonable.

It also leaves the caller to execute multiple runs, if so desired.