### PR TITLE
Fix flaky clockwork tests from #44.

### DIFF
--- a/context_test.go
+++ b/context_test.go
@@ -7,6 +7,7 @@ import (
 )
 
 func TestContextOps(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	assertIsType(t, NewRealClock(), FromContext(ctx))
 
@@ -17,9 +18,8 @@ func TestContextOps(t *testing.T) {
 	assertIsType(t, NewRealClock(), FromContext(ctx))
 }
 
-func assertIsType(t *testing.T, expectedType interface{}, object interface{}) {
+func assertIsType(t *testing.T, expectedType, object interface{}) {
 	t.Helper()
-
 	if reflect.TypeOf(object) != reflect.TypeOf(expectedType) {
 		t.Fatalf("Object expected to be of type %v, but was %v", reflect.TypeOf(expectedType), reflect.TypeOf(object))
 	}

--- a/example_test.go
+++ b/example_test.go
@@ -6,21 +6,20 @@ import (
 	"time"
 )
 
-// myFunc is an example of a time-dependent function, using an
-// injected clock
+// myFunc is an example of a time-dependent function, using an injected clock.
 func myFunc(clock Clock, i *int) {
 	clock.Sleep(3 * time.Second)
 	*i += 1
 }
 
-// assertState is an example of a state assertion in a test
+// assertState is an example of a state assertion in a test.
 func assertState(t *testing.T, i, j int) {
 	if i != j {
 		t.Fatalf("i %d, j %d", i, j)
 	}
 }
 
-// TestMyFunc tests myFunc's behaviour with a FakeClock
+// TestMyFunc tests myFunc's behaviour with a FakeClock.
 func TestMyFunc(t *testing.T) {
 	var i int
 	c := NewFakeClock()
@@ -32,18 +31,18 @@ func TestMyFunc(t *testing.T) {
 		wg.Done()
 	}()
 
-	// Wait until myFunc is actually sleeping on the clock
+	// Wait until myFunc is actually sleeping on the clock.
 	c.BlockUntil(1)
 
-	// Assert the initial state
+	// Assert the initial state.
 	assertState(t, i, 0)
 
-	// Now advance the clock forward in time
+	// Now advance the clock forward in time.
 	c.Advance(1 * time.Hour)
 
-	// Wait until the function completes
+	// Wait until the function completes.
 	wg.Wait()
 
-	// Assert the final state
+	// Assert the final state.
 	assertState(t, i, 1)
 }

--- a/timer_test.go
+++ b/timer_test.go
@@ -1,11 +1,13 @@
 package clockwork
 
 import (
+	"context"
 	"testing"
 	"time"
 )
 
 func TestFakeClockTimerStop(t *testing.T) {
+	t.Parallel()
 	fc := &fakeClock{}
 
 	ft := fc.NewTimer(1)
@@ -18,6 +20,10 @@ func TestFakeClockTimerStop(t *testing.T) {
 }
 
 func TestFakeClockTimers(t *testing.T) {
+	t.Parallel()
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
 	fc := &fakeClock{}
 
 	zero := fc.NewTimer(0)
@@ -26,12 +32,9 @@ func TestFakeClockTimers(t *testing.T) {
 		t.Errorf("zero timer could be stopped")
 	}
 
-	timeout := time.NewTimer(500 * time.Millisecond)
-	defer timeout.Stop()
-
 	select {
 	case <-zero.Chan():
-	case <-timeout.C:
+	case <-ctx.Done():
 		t.Errorf("zero timer didn't emit time")
 	}
 
@@ -71,12 +74,9 @@ func TestFakeClockTimers(t *testing.T) {
 		t.Errorf("triggered timer could be stopped")
 	}
 
-	timeout2 := time.NewTimer(500 * time.Millisecond)
-	defer timeout2.Stop()
-
 	select {
 	case <-one.Chan():
-	case <-timeout2.C:
+	case <-ctx.Done():
 		t.Errorf("triggered timer didn't emit time")
 	}
 
@@ -94,36 +94,32 @@ func TestFakeClockTimers(t *testing.T) {
 		t.Errorf("reset to zero timer could be stopped")
 	}
 
-	timeout3 := time.NewTimer(500 * time.Millisecond)
-	defer timeout3.Stop()
-
 	select {
 	case <-one.Chan():
-	case <-timeout3.C:
+	case <-ctx.Done():
 		t.Errorf("reset to zero timer didn't emit time")
 	}
 }
 
 func TestFakeClockTimer_Race(t *testing.T) {
-	fc := NewFakeClock()
+	t.Parallel()
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
 
+	fc := NewFakeClock()
 	timer := fc.NewTimer(1 * time.Millisecond)
 	defer timer.Stop()
-
 	fc.Advance(1 * time.Millisecond)
-
-	timeout := time.NewTimer(500 * time.Millisecond)
-	defer timeout.Stop()
 
 	select {
 	case <-timer.Chan():
-		// Pass
-	case <-timeout.C:
+	case <-ctx.Done():
 		t.Fatalf("Timer didn't detect the clock advance!")
 	}
 }
 
 func TestFakeClockTimer_Race2(t *testing.T) {
+	t.Parallel()
 	fc := NewFakeClock()
 	timer := fc.NewTimer(5 * time.Second)
 	for i := 0; i < 100; i++ {
@@ -140,12 +136,14 @@ func TestFakeClockTimer_ResetRace(t *testing.T) {
 	d := 5 * time.Second
 	var times []time.Time
 	timer := fc.NewTimer(d)
-	done := make(chan struct{})
+	timerStopped := make(chan struct{})
+	doneAddingTimes := make(chan struct{})
 	go func() {
+		defer close(doneAddingTimes)
 		for {
 			select {
-			case <-done:
-				break
+			case <-timerStopped:
+				return
 			case now := <-timer.Chan():
 				times = append(times, now)
 			}
@@ -158,9 +156,10 @@ func TestFakeClockTimer_ResetRace(t *testing.T) {
 		fc.Advance(d)
 	}
 	timer.Stop()
-	close(done)
+	close(timerStopped)
+	<-doneAddingTimes // Prevent race condition on times.
 	for i := 1; i < len(times); i++ {
-		if times[i-1] == times[i] {
+		if times[i-1].Equal(times[i]) {
 			t.Fatalf("Timer repeatedly reported the same time.")
 		}
 	}
@@ -177,9 +176,9 @@ func TestFakeClockTimer_ZeroResetDoesNotBlock(t *testing.T) {
 }
 
 func TestAfterFunc_Concurrent(t *testing.T) {
-	timeout := time.NewTimer(500 * time.Millisecond)
-	defer timeout.Stop()
-
+	t.Parallel()
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
 	fc := NewFakeClock()
 	blocker := make(chan struct{})
 	ch := make(chan int)
@@ -202,7 +201,7 @@ func TestAfterFunc_Concurrent(t *testing.T) {
 		if a != 111 {
 			t.Fatalf("Expected 111, got %d", a)
 		}
-	case <-timeout.C:
+	case <-ctx.Done():
 		t.Fatalf("Expected signal hasn't arrived")
 	}
 	close(blocker)
@@ -211,7 +210,7 @@ func TestAfterFunc_Concurrent(t *testing.T) {
 		if a != 222 {
 			t.Fatalf("Expected 222, got %d", a)
 		}
-	case <-timeout.C:
+	case <-ctx.Done():
 		t.Fatalf("Expected signal hasn't arrived")
 	}
 	select {
@@ -219,7 +218,7 @@ func TestAfterFunc_Concurrent(t *testing.T) {
 		if a != 222 {
 			t.Fatalf("Expected 222, got %d", a)
 		}
-	case <-timeout.C:
+	case <-ctx.Done():
 		t.Fatalf("Expected signal hasn't arrived")
 	}
 }


### PR DESCRIPTION
- Only run `TestFakeTicker_DeliveryOrder` once per invocation.
- Use channels to avoid race condition in `TestFakeClockTimer_ResetRace`.
- Run tests in parallel.

Tested:
- Run 10,000 times with 2 timeout flakes (i.e. 0.02% flake rate, likely due to slow machines)
- Ran with `-race`, no race conditions reported.