### PR TITLE
Move lock logic to fakeClock. Reduce Ticker and Timer code complexity.

### DIFF
--- a/clockwork_test.go
+++ b/clockwork_test.go
@@ -89,7 +89,7 @@ func TestNotifyBlockers(t *testing.T) {
 	b5 := &blocker{10, make(chan struct{})}
 	fc := fakeClock{
 		blockers: []*blocker{b1, b2, b3, b4, b5},
-		sleepers: sleepers{nil, nil},
+		waiters:  []expirer{nil, nil},
 	}
 	fc.notifyBlockers()
 	if n := len(fc.blockers); n != 3 {
@@ -105,8 +105,8 @@ func TestNotifyBlockers(t *testing.T) {
 	case <-time.After(time.Second):
 		t.Fatalf("timed out waiting for channel close!")
 	}
-	for len(fc.sleepers) < 10 {
-		fc.sleepers = append(fc.sleepers, nil)
+	for len(fc.waiters) < 10 {
+		fc.waiters = append(fc.waiters, nil)
 	}
 	fc.notifyBlockers()
 	if n := len(fc.blockers); n != 0 {

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/jonboulle/clockwork
 
-go 1.13
+go 1.15

--- a/ticker.go
+++ b/ticker.go
@@ -1,29 +1,48 @@
 package clockwork
 
-import (
-	"time"
-)
+import "time"
 
-// Ticker provides an interface which can be used instead of directly
-// using the ticker within the time module. The real-time ticker t
-// provides ticks through t.C which becomes now t.Chan() to make
-// this channel requirement definable in this interface.
+// Ticker provides an interface which can be used instead of directly using
+// [time.Ticker]. The real-time ticker t provides ticks through t.C which
+// becomes t.Chan() to make this channel requirement definable in this
+// interface.
 type Ticker interface {
 	Chan() <-chan time.Time
+	Reset(d time.Duration)
 	Stop()
 }
 
 type realTicker struct{ *time.Ticker }
 
-func (rt realTicker) Chan() <-chan time.Time {
-	return rt.C
+func (r realTicker) Chan() <-chan time.Time {
+	return r.C
 }
 
 type fakeTicker struct {
-	fakeTimer
+	firer
+
+	// reset and stop provide the implmenetation of the respective exported
+	// functions.
+	reset func(d time.Duration)
+	stop  func()
+
+	// The duration of the ticker.
+	d time.Duration
 }
 
-func (ft *fakeTicker) Stop() {
-	// Ignore returned bool to make signature match.
-	ft.fakeTimer.Stop()
+func (f *fakeTicker) Reset(d time.Duration) {
+	f.reset(d)
+}
+
+func (f *fakeTicker) Stop() {
+	f.stop()
+}
+
+func (f *fakeTicker) expire(now time.Time) *time.Duration {
+	// Never block on expiration.
+	select {
+	case f.c <- now:
+	default:
+	}
+	return &f.d
 }

--- a/timer.go
+++ b/timer.go
@@ -1,88 +1,53 @@
 package clockwork
 
-import (
-	"sort"
-	"time"
-)
+import "time"
 
-// Timer provides an interface which can be used instead of directly
-// using the timer within the time module. The real-time timer t
-// provides events through t.C which becomes now t.Chan() to make
-// this channel requirement definable in this interface.
+// Timer provides an interface which can be used instead of directly using
+// [time.Timer]. The real-time timer t provides events through t.C which becomes
+// t.Chan() to make this channel requirement definable in this interface.
 type Timer interface {
 	Chan() <-chan time.Time
 	Reset(d time.Duration) bool
 	Stop() bool
 }
 
-type realTimer struct {
-	*time.Timer
-}
+type realTimer struct{ *time.Timer }
 
 func (r realTimer) Chan() <-chan time.Time {
 	return r.C
 }
 
 type fakeTimer struct {
-	// The channel associated with this timer. Only relevant for timers that
-	// originate from NewTimer or similar, i.e. not for AfterFunc or other
-	// internal usage.
-	c chan time.Time
+	firer
 
-	// The fake clock driving events for this timer.
-	clock *fakeClock
+	// reset and stop provide the implmenetation of the respective exported
+	// functions.
+	reset func(d time.Duration) bool
+	stop  func() bool
 
-	// The time when the timer expires. Only meaningful if the timer is currently
-	// one of the fake clock's sleepers.
-	until time.Time
-
-	// callback will get called synchronously with the lock of the clock being
-	// held. It receives the time at which the timer expired.
-	callback func(time.Time)
-}
-
-func (f *fakeTimer) Chan() <-chan time.Time {
-	return f.c
-}
-
-func (f *fakeTimer) Stop() bool {
-	f.clock.l.Lock()
-	defer f.clock.l.Unlock()
-	return f.stopImpl()
-}
-
-func (f *fakeTimer) stopImpl() bool {
-	for i, t := range f.clock.sleepers {
-		if t == f {
-			// Remove element, maintaining order.
-			copy(f.clock.sleepers[i:], f.clock.sleepers[i+1:])
-			f.clock.sleepers[len(f.clock.sleepers)-1] = nil
-			f.clock.sleepers = f.clock.sleepers[:len(f.clock.sleepers)-1]
-			return true
-		}
-	}
-	return false
+	// If present when the timer fires, the timer calls afterFunc in its own
+	// goroutine rather than sending the time on Chan().
+	afterFunc func()
 }
 
 func (f *fakeTimer) Reset(d time.Duration) bool {
-	f.clock.l.Lock()
-	defer f.clock.l.Unlock()
-	stopped := f.stopImpl()
-	f.resetImpl(d)
-	return stopped
+	return f.reset(d)
 }
 
-func (f *fakeTimer) resetImpl(d time.Duration) {
-	now := f.clock.time
-	if d.Nanoseconds() <= 0 {
-		// special case - trigger immediately
-		f.callback(now)
-	} else {
-		// otherwise, add to the set of sleepers
-		f.until = f.clock.time.Add(d)
-		f.clock.sleepers = append(f.clock.sleepers, f)
-		sort.Sort(f.clock.sleepers)
-		// and notify any blockers
-		f.clock.notifyBlockers()
+func (f *fakeTimer) Stop() bool {
+	return f.stop()
+}
+
+func (f *fakeTimer) expire(now time.Time) *time.Duration {
+	if f.afterFunc != nil {
+		go f.afterFunc()
+		return nil
 	}
+
+	// Never block on expiration.
+	select {
+	case f.c <- now:
+	default:
+	}
+	return nil
 }


### PR DESCRIPTION
- Minimize the custom logic of Tickers and Timers.
- Don't allow Tickers and Timers to access to the lock of the fakeClock that controls them. Use closures instead.
- Use a common `expirer` interface for Timers and Tickers, rather than reusing Timers for both.
- Create a `firer` struct to handle commonalities between Tickers and Timers.
- Use a single function & code path for Timers, regardless of if they are made with NewTimer or AfterFunc.
- Add Reset to Ticker interface, which was added in go 1.15.
- Use the mutex hat pattern and add documentation on what the mutex protects.
- Change field name/type from "sleeper"/"timer" to "waiter"/"expirer" and add documentation.
- Various documentation updates.
- Sort expirers using a sort.Slices.
- NIT: Use the standard layout time as the default for NewFakeClock.
- Style NIT: Return/continue early where possible.

Tested: All tests pass, no race conditions from `go -race`.