### PR TITLE
chore: bump minimum Go version to 1.15

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,9 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go: ['1.11', '1.12', '1.13', '1.14', '1.15', '1.16', '1.17', '1.18']
-    env:
-      GOFLAGS: -mod=readonly
+        go: ['1.15', '1.16', '1.17', '1.18', '1.19']
 
     steps:
       - name: Set up Go

--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 [![Mentioned in Awesome Go](https://awesome.re/mentioned-badge-flat.svg)](https://github.com/avelino/awesome-go#utilities)
 
-[![GitHub Workflow Status](https://img.shields.io/github/workflow/status/jonboulle/clockwork/CI?style=flat-square)](https://github.com/jonboulle/clockwork/actions?query=workflow%3ACI)
+[![GitHub Workflow Status](https://img.shields.io/github/actions/workflow/status/jonboulle/clockwork/ci.yaml?style=flat-square)](https://github.com/jonboulle/clockwork/actions?query=workflow%3ACI)
 [![Go Report Card](https://goreportcard.com/badge/github.com/jonboulle/clockwork?style=flat-square)](https://goreportcard.com/report/github.com/jonboulle/clockwork)
-![Go Version](https://img.shields.io/badge/go%20version-%3E=1.11-61CFDD.svg?style=flat-square)
+![Go Version](https://img.shields.io/badge/go%20version-%3E=1.15-61CFDD.svg?style=flat-square)
 [![go.dev reference](https://img.shields.io/badge/go.dev-reference-007d9c?logo=go&logoColor=white&style=flat-square)](https://pkg.go.dev/mod/github.com/jonboulle/clockwork)
 
 **A simple fake clock for Go.**

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/jonboulle/clockwork
 
-go 1.13
+go 1.15


### PR DESCRIPTION
Signed-off-by: Mark Sagi-Kazar <mark.sagikazar@gmail.com>