### PR TITLE
Use the current time for NewFakeClock's initial value

### DIFF
--- a/clockwork.go
+++ b/clockwork.go
@@ -43,10 +43,11 @@ func NewRealClock() Clock {
 
 // NewFakeClock returns a FakeClock implementation which can be
 // manually advanced through time for testing. The initial time of the
-// FakeClock will be an arbitrary non-zero time.
+// FakeClock will be the current system time.
+//
+// Tests that require a deterministic time must use NewFakeClockAt.
 func NewFakeClock() FakeClock {
-	// Use the standard layout time to avoid fulfilling Time.IsZero().
-	return NewFakeClockAt(time.Date(2006, time.January, 2, 15, 4, 5, 0, time.UTC))
+	return NewFakeClockAt(time.Now())
 }
 
 // NewFakeClockAt returns a FakeClock initialised at the given time.Time.


### PR DESCRIPTION
This prevents callers from building tests that rely on implementation details. Typically by expecting a time or string value computed from NewFakeClock().Now().

This philosophy of preventing users from relying on implementation internals is similar to Go's random map iteration behavior. For users who depend on the initial clock time, NewFakeClockAt() provides the behavior they need, and makes their expectations clear in tests.

This also ensures that future changes that might need to modify the default time for whatever reason won't cause mass breakage, as this author learned about the hard way.