### PR TITLE
Add a WithSynchronousAfterFunc option

### DIFF
--- a/clockwork.go
+++ b/clockwork.go
@@ -45,11 +45,11 @@ func NewRealClock() Clock {
 type FakeClockOption func(*fakeClock)
 
 // WithSynchronousAfterFunc is a FakeClockOption which ensures that the callback to AfterFunc is called synchronously
-// instead of in a separate goroutine. If true, this option will cause any Advance calls to block until the callback
+// instead of in a separate goroutine. If set, this option will cause any Advance calls to block until the callback
 // from all fired timers has completed.
-func WithSynchronousAfterFunc(b bool) FakeClockOption {
+func WithSynchronousAfterFunc() FakeClockOption {
 	return func(c *fakeClock) {
-		c.synchronousAfterFunc = b
+		c.synchronousAfterFunc = true
 	}
 }
 

--- a/clockwork_test.go
+++ b/clockwork_test.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"reflect"
-	"sync/atomic"
 	"testing"
 	"time"
 )
@@ -204,22 +203,22 @@ func TestFakeClockRace(t *testing.T) {
 
 func TestFakeClockSynchronousAfterFunc(t *testing.T) {
 	t.Parallel()
-	fc := NewFakeClock(WithSynchronousAfterFunc(true))
-	var called atomic.Bool
+	fc := NewFakeClock(WithSynchronousAfterFunc())
+	var called bool
 	fc.AfterFunc(time.Second, func() {
-		called.Store(true)
+		called = true
 	})
-	if called.Load() {
+	if called {
 		t.Fatal("AfterFunc called before Advance")
 	}
 	fc.Advance(time.Second)
-	if !called.Load() {
+	if !called {
 		t.Fatal("AfterFunc not called after Advance")
 	}
 }
 
 func ExampleWithSynchronousAfterFunc() {
-	fc := NewFakeClock(WithSynchronousAfterFunc(true))
+	fc := NewFakeClock(WithSynchronousAfterFunc())
 	fc.AfterFunc(time.Second, func() {
 		fmt.Println("AfterFunc called")
 	})

--- a/example_test.go
+++ b/example_test.go
@@ -58,7 +58,7 @@ func TestMyFunc2(t *testing.T) {
 	var i int
 
 	// Use WithSynchronousAfterFunc to ensure that the AfterFunc callback is called by the time Advance returns.
-	c := NewFakeClock(WithSynchronousAfterFunc(true))
+	c := NewFakeClock(WithSynchronousAfterFunc())
 
 	// Call myFunc2, which will schedule a callback to increment i.
 	myFunc2(c, &i)

--- a/example_test.go
+++ b/example_test.go
@@ -46,3 +46,29 @@ func TestMyFunc(t *testing.T) {
 	// Assert the final state.
 	assertState(t, i, 1)
 }
+
+// myFunc2 is an example of a time-dependent function which uses AfterFunc.
+func myFunc2(clock Clock, i *int) {
+	clock.AfterFunc(3*time.Second, func() {
+		*i += 1
+	})
+}
+
+func TestMyFunc2(t *testing.T) {
+	var i int
+
+	// Use WithSynchronousAfterFunc to ensure that the AfterFunc callback is called by the time Advance returns.
+	c := NewFakeClock(WithSynchronousAfterFunc(true))
+
+	// Call myFunc2, which will schedule a callback to increment i.
+	myFunc2(c, &i)
+
+	// Assert the initial state.
+	assertState(t, i, 0)
+
+	// Now advance the clock forward in time to trigger the callback.
+	c.Advance(3 * time.Second)
+
+	// Assert the final state.
+	assertState(t, i, 1)
+}

--- a/timer.go
+++ b/timer.go
@@ -28,6 +28,8 @@ type fakeTimer struct {
 	// If present when the timer fires, the timer calls afterFunc in its own
 	// goroutine rather than sending the time on Chan().
 	afterFunc func()
+	// synchronousAfterFunc indicates that the afterFunc should be called in the same goroutine as the timer.
+	synchronousAfterFunc bool
 }
 
 func (f *fakeTimer) Reset(d time.Duration) bool {
@@ -40,7 +42,11 @@ func (f *fakeTimer) Stop() bool {
 
 func (f *fakeTimer) expire(now time.Time) *time.Duration {
 	if f.afterFunc != nil {
-		go f.afterFunc()
+		if f.synchronousAfterFunc {
+			f.afterFunc()
+		} else {
+			go f.afterFunc()
+		}
 		return nil
 	}
 


### PR DESCRIPTION
This is for https://github.com/jonboulle/clockwork/issues/67

I'm happy to add more context if you'd like, but the main idea is that this makes it a lot easier to test certain things. For example, if you want to verify that a timer did fire without this option, you could just block for a while and wait for it to return. However, if you wanted to verify that timer did *not* fire, you'd have to set an arbitrary wait amount. 