### PR TITLE
Add Expirations() and BlockUntilContext(...) to FakeClock.

### DIFF
--- a/timer.go
+++ b/timer.go
@@ -20,7 +20,7 @@ func (r realTimer) Chan() <-chan time.Time {
 type fakeTimer struct {
 	firer
 
-	// reset and stop provide the implmenetation of the respective exported
+	// reset and stop provide the implementation of the respective exported
 	// functions.
 	reset func(d time.Duration) bool
 	stop  func() bool


### PR DESCRIPTION
- Expirations() allows callers to validate that AfterFunc was not called.
- BlockUntilContext(...) added to FakeClock. It was added to fakeClock previously but never exposed in the interface. Oops.
- Other NITs: documentation, spellin'

We choose to add both functions in the same commit because any change to the interface requires toilsome updates by downstream users who impelement the interface*. Might as well do both functions at once.

"Go interfaces generally belong in the package that consumes values of the interface type, not a package that implements the interface type." - https://google.github.io/styleguide/go/decisions.html#interfaces

For clarification, the above quote doesn't apply to `clockwork.Clock` because providing that interface is the intent of this package. However, `clockwork.FakeClock`'s status as an interface means we break downstream users every time we update it :(