### PR TITLE
Convert FakeClock to a struct.

### DIFF
--- a/clockwork_test.go
+++ b/clockwork_test.go
@@ -15,7 +15,7 @@ const timeout = time.Minute
 
 func TestFakeClockAfter(t *testing.T) {
 	t.Parallel()
-	fc := &fakeClock{}
+	fc := &FakeClock{}
 
 	neg := fc.After(-1)
 	select {
@@ -128,7 +128,7 @@ func TestFakeClockSince(t *testing.T) {
 // https://github.com/jonboulle/clockwork/issues/35
 func TestTwoBlockersOneBlock(t *testing.T) {
 	t.Parallel()
-	fc := &fakeClock{}
+	fc := &FakeClock{}
 
 	ft1 := fc.NewTicker(time.Second)
 	ft2 := fc.NewTicker(time.Second)
@@ -141,7 +141,7 @@ func TestTwoBlockersOneBlock(t *testing.T) {
 
 func TestBlockUntilContext(t *testing.T) {
 	t.Parallel()
-	fc := &fakeClock{}
+	fc := &FakeClock{}
 
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
@@ -163,13 +163,13 @@ func TestBlockUntilContext(t *testing.T) {
 			t.Errorf("BlockUntilContext returned %v, want context.Canceled.", err)
 		}
 	case <-ctx.Done():
-		t.Errorf("Never receved error on context cancellation.")
+		t.Errorf("Never received error on context cancellation.")
 	}
 }
 
 func TestAfterDeliveryInOrder(t *testing.T) {
 	t.Parallel()
-	fc := &fakeClock{}
+	fc := &FakeClock{}
 	for i := 0; i < 1000; i++ {
 		three := fc.After(3 * time.Second)
 		for j := 0; j < 100; j++ {
@@ -192,7 +192,7 @@ func TestAfterDeliveryInOrder(t *testing.T) {
 // There are no failure conditions when invoked without the -race flag.
 func TestFakeClockRace(t *testing.T) {
 	t.Parallel()
-	fc := &fakeClock{}
+	fc := &FakeClock{}
 	d := time.Second
 	go func() { fc.Advance(d) }()
 	go func() { fc.NewTicker(d) }()

--- a/ticker_test.go
+++ b/ticker_test.go
@@ -8,7 +8,7 @@ import (
 
 func TestFakeTickerStop(t *testing.T) {
 	t.Parallel()
-	fc := &fakeClock{}
+	fc := &FakeClock{}
 
 	ft := fc.NewTicker(1)
 	ft.Stop()
@@ -24,7 +24,7 @@ func TestFakeTickerTick(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
 
-	fc := &fakeClock{}
+	fc := &FakeClock{}
 	now := fc.Now()
 
 	// The tick at now.Add(2) should not get through since we advance time by

--- a/timer_test.go
+++ b/timer_test.go
@@ -8,7 +8,7 @@ import (
 
 func TestFakeClockTimerStop(t *testing.T) {
 	t.Parallel()
-	fc := &fakeClock{}
+	fc := &FakeClock{}
 
 	ft := fc.NewTimer(1)
 	ft.Stop()
@@ -24,7 +24,7 @@ func TestFakeClockTimers(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
 
-	fc := &fakeClock{}
+	fc := &FakeClock{}
 
 	zero := fc.NewTimer(0)
 


### PR DESCRIPTION
This change ensures future modifications to FakeClock will not break users.

However, this change does break current users who use FakeClock as an argument, return value, or embed it in a struct or interface.

With limtied exception, build errors can be fixed by running:
```
$ grep -rl 'clockwork.FakeClock' /path/to/code_base | \
    xargs sed -i 's/clockwork.FakeClock/*clockwork.FakeClock/g'
```

Other rare build errors and their fixes are:
- When returning a pointer to concrete type as a `clockwork.FakeClock`: return the pointer to concrete type instead.
- When using `clockwork.FakeClock` in an interface composition: relace with the functions required by the interface.
- When using `clockwork.FakeClock` as an argument, replace with concerete type or define a new interface.

The anternative approach would have been to use type alaises. However, this does not provide a benefit over direct replacement, because the migration is more complicated, harder to execute, needs to be done to the same code points, and results in runtime failures when type converting (whereas this approach only fails at complie-time).