### PR TITLE
Fix typos and grammar issue

### DIFF
--- a/clockwork.go
+++ b/clockwork.go
@@ -323,7 +323,7 @@ func (fc *FakeClock) setExpirer(e expirer, d time.Duration) {
 
 // firer is used by fakeTimer and fakeTicker used to help implement expirer.
 type firer struct {
-	// The channel associated with the firer, used to send expriation times.
+	// The channel associated with the firer, used to send expiration times.
 	c chan time.Time
 
 	// The time when the firer expires. Only meaningful if the firer is currently

--- a/context.go
+++ b/context.go
@@ -4,7 +4,7 @@ import (
 	"context"
 )
 
-// contextKey is private to this package so we can ensure uniqueness here. This
+// contextKey is private to this package, so we can ensure uniqueness here. This
 // type identifies context values provided by this package.
 type contextKey string
 

--- a/timer.go
+++ b/timer.go
@@ -20,7 +20,7 @@ func (r realTimer) Chan() <-chan time.Time {
 type fakeTimer struct {
 	firer
 
-	// reset and stop provide the implmenetation of the respective exported
+	// reset and stop provide the implementation of the respective exported
 	// functions.
 	reset func(d time.Duration) bool
 	stop  func() bool


### PR DESCRIPTION
This PR fixes typos in comments, and add missing comma before `so`.