### PR TITLE
Set minimal workflow permissions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -5,6 +5,9 @@ on:
     branches: [master]
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   test:
     name: Test

--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -20,13 +20,15 @@ on:
   schedule:
     - cron: '27 12 * * 0'
 
+permissions:
+  contents: read
+
 jobs:
   analyze:
     name: Analyze
     runs-on: ubuntu-latest
     permissions:
       actions: read
-      contents: read
       security-events: write
 
     strategy:


### PR DESCRIPTION
Fixes #74.

This PR ensures workflows run with minimal permissions, protecting the project from supply-chain attacks.

The change to codeql.yaml is for consistency and future-proofing: if another job is added to the workflow in the future, it will run with just `contents: read` instead of `write-all`.