### PR TITLE
 Add security policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,19 @@
+# Security Policy
+
+If you have discovered a security vulnerability in this project, please report it
+privately. **Do not disclose it as a public issue.** This gives me time to work with you
+to fix the issue before public exposure, reducing the chance that the exploit will be
+used before a patch is released.
+
+You may submit the report in the following ways:
+
+- send an email to ???@???; and/or
+- send a [private vulnerability report](https://github.com/jonboulle/clockwork/security/advisories/new)
+
+Please provide the following information in your report:
+
+- A description of the vulnerability and its impact
+- How to reproduce the issue
+
+This project is maintained by a single maintainer on a reasonable-effort basis. As such,
+please give me 90 days to work on a fix before public exposure.


### PR DESCRIPTION
Fixes #77.

This PR adds a simple security policy to the repository.

The policy currently suggests sending the report to an email (currently just a placeholder!) or using GitHub's private vulnerability reports.

Let me know if you'd like to use just one of these or if there are any other changes you'd like.