### PR TITLE
add Until method on clock interface

### DIFF
--- a/clockwork.go
+++ b/clockwork.go
@@ -16,6 +16,7 @@ type Clock interface {
 	Sleep(d time.Duration)
 	Now() time.Time
 	Since(t time.Time) time.Duration
+	Until(t time.Time) time.Duration
 	NewTicker(d time.Duration) Ticker
 	NewTimer(d time.Duration) Timer
 	AfterFunc(d time.Duration, f func()) Timer
@@ -43,6 +44,10 @@ func (rc *realClock) Now() time.Time {
 
 func (rc *realClock) Since(t time.Time) time.Duration {
 	return rc.Now().Sub(t)
+}
+
+func (rc *realClock) Until(t time.Time) time.Duration {
+	return t.Sub(rc.Now())
 }
 
 func (rc *realClock) NewTicker(d time.Duration) Ticker {
@@ -130,6 +135,12 @@ func (fc *FakeClock) Now() time.Time {
 // fakeClock.
 func (fc *FakeClock) Since(t time.Time) time.Duration {
 	return fc.Now().Sub(t)
+}
+
+// Until returns the duration that has to pass from the given time on the fakeClock
+// to reach the given time.
+func (fc *FakeClock) Until(t time.Time) time.Duration {
+	return t.Sub(fc.Now())
 }
 
 // NewTicker returns a Ticker that will expire only after calls to

--- a/clockwork_test.go
+++ b/clockwork_test.go
@@ -124,6 +124,23 @@ func TestFakeClockSince(t *testing.T) {
 	}
 }
 
+func TestFakeClockUntil(t *testing.T) {
+	t.Parallel()
+	testTime := time.Now()
+	fc := NewFakeClockAt(testTime)
+
+	testOffset := time.Minute
+	probeTime := testTime.Add(testOffset)
+
+	elapsedTime := time.Second
+	fc.Advance(elapsedTime)
+
+	expectedDuration := testOffset - elapsedTime
+	if fc.Until(probeTime) != expectedDuration {
+		t.Fatalf("fakeClock.Until() returned unexpected duration, got: %d, want: %d", fc.Until(probeTime), expectedDuration)
+	}
+}
+
 // This used to result in a deadlock.
 // https://github.com/jonboulle/clockwork/issues/35
 func TestTwoBlockersOneBlock(t *testing.T) {


### PR DESCRIPTION
The clockwork package has a `Since` method for measuring duration between a time in the past and the current time.
The go standard lib `time` has an [`Until` method](https://pkg.go.dev/time#Until), in addition to `Since`.
There's quite a few cases (at least, in my software) where it would be far 'neater' to have `Until` than doing the negative of `Since`. 

This PR adds an `Until` method to the clock interface, with tests.
I am not sure on what the general philosophy around this package is - i.e. if you even want `Until`, but I thought it would be worthwhile to open a PR.

Thank you for your work on Clockwork, I would be delighted to have any feedback to try and make my contributions better :smile: 