### PR TITLE
Introduce context aware helpers for context related testing

### DIFF
--- a/clockwork.go
+++ b/clockwork.go
@@ -19,6 +19,8 @@ type Clock interface {
 	NewTicker(d time.Duration) Ticker
 	NewTimer(d time.Duration) Timer
 	AfterFunc(d time.Duration, f func()) Timer
+	WithTimeout(parent context.Context, timeout time.Duration) (context.Context, context.CancelFunc)
+	WithDeadline(parent context.Context, deadline time.Time) (context.Context, context.CancelFunc)
 }
 
 // NewRealClock returns a Clock which simply delegates calls to the actual time

--- a/clockwork.go
+++ b/clockwork.go
@@ -19,8 +19,6 @@ type Clock interface {
 	NewTicker(d time.Duration) Ticker
 	NewTimer(d time.Duration) Timer
 	AfterFunc(d time.Duration, f func()) Timer
-	WithTimeout(parent context.Context, timeout time.Duration) (context.Context, context.CancelFunc)
-	WithDeadline(parent context.Context, deadline time.Time) (context.Context, context.CancelFunc)
 }
 
 // NewRealClock returns a Clock which simply delegates calls to the actual time

--- a/context.go
+++ b/context.go
@@ -2,6 +2,9 @@ package clockwork
 
 import (
 	"context"
+	"fmt"
+	"sync"
+	"time"
 )
 
 // contextKey is private to this package so we can ensure uniqueness here. This
@@ -27,4 +30,90 @@ func FromContext(ctx context.Context) Clock {
 		return clock
 	}
 	return NewRealClock()
+}
+
+func (rc *realClock) WithTimeout(parent context.Context, timeout time.Duration) (context.Context, context.CancelFunc) {
+	return context.WithTimeout(parent, timeout)
+}
+
+func (rc *realClock) WithDeadline(parent context.Context, deadline time.Time) (context.Context, context.CancelFunc) {
+	return context.WithDeadline(parent, deadline)
+}
+
+func (fc *FakeClock) WithTimeout(parent context.Context, timeout time.Duration) (context.Context, context.CancelFunc) {
+	return fc.WithDeadline(parent, fc.Now().Add(timeout))
+}
+
+func (fc *FakeClock) WithDeadline(parent context.Context, deadline time.Time) (context.Context, context.CancelFunc) {
+	if cur, ok := parent.Deadline(); ok && cur.Before(deadline) {
+		// The current deadline is already sooner than the new one.
+		return context.WithCancel(parent)
+	}
+	ctx := &timerCtx{clock: fc, parent: parent, deadline: deadline, done: make(chan struct{})}
+	propagateCancel(parent, ctx)
+	dur := deadline.Sub(fc.Now())
+	if dur <= 0 {
+		ctx.cancel(context.DeadlineExceeded) // deadline has already passed
+		return ctx, func() {}
+	}
+	ctx.Lock()
+	defer ctx.Unlock()
+	if ctx.err == nil {
+		ctx.timer = fc.AfterFunc(dur, func() {
+			ctx.cancel(context.DeadlineExceeded)
+		})
+	}
+	return ctx, func() { ctx.cancel(context.Canceled) }
+}
+
+// propagateCancel arranges for child to be canceled when parent is.
+func propagateCancel(parent context.Context, child *timerCtx) {
+	if parent.Done() == nil {
+		return // parent is never canceled
+	}
+	go func() {
+		select {
+		case <-parent.Done():
+			child.cancel(parent.Err())
+		case <-child.Done():
+		}
+	}()
+}
+
+type timerCtx struct {
+	sync.Mutex
+
+	clock    Clock
+	parent   context.Context
+	deadline time.Time
+	done     chan struct{}
+
+	err   error
+	timer Timer
+}
+
+func (c *timerCtx) cancel(err error) {
+	c.Lock()
+	defer c.Unlock()
+	if c.err != nil {
+		return // already canceled
+	}
+	c.err = err
+	close(c.done)
+	if c.timer != nil {
+		c.timer.Stop()
+		c.timer = nil
+	}
+}
+
+func (c *timerCtx) Deadline() (deadline time.Time, ok bool) { return c.deadline, true }
+
+func (c *timerCtx) Done() <-chan struct{} { return c.done }
+
+func (c *timerCtx) Err() error { return c.err }
+
+func (c *timerCtx) Value(key interface{}) interface{} { return c.parent.Value(key) }
+
+func (c *timerCtx) String() string {
+	return fmt.Sprintf("clock.WithDeadline(%s [%s])", c.deadline, c.deadline.Sub(c.clock.Now()))
 }

--- a/context_test.go
+++ b/context_test.go
@@ -2,8 +2,10 @@ package clockwork
 
 import (
 	"context"
+	"errors"
 	"reflect"
 	"testing"
+	"time"
 )
 
 func TestContextOps(t *testing.T) {
@@ -22,5 +24,97 @@ func assertIsType(t *testing.T, expectedType, object interface{}) {
 	t.Helper()
 	if reflect.TypeOf(object) != reflect.TypeOf(expectedType) {
 		t.Fatalf("Object expected to be of type %v, but was %v", reflect.TypeOf(expectedType), reflect.TypeOf(object))
+	}
+}
+
+// Ensure that WithDeadline is cancelled when deadline exceeded.
+func TestFakeClock_WithDeadline(t *testing.T) {
+	m := NewFakeClock()
+	now := m.Now()
+	ctx, _ := m.WithDeadline(context.Background(), now.Add(time.Second))
+	m.Advance(time.Second)
+	select {
+	case <-ctx.Done():
+		if !errors.Is(ctx.Err(), context.DeadlineExceeded) {
+			t.Error("invalid type of error returned when deadline exceeded")
+		}
+	default:
+		t.Error("context is not cancelled when deadline exceeded")
+	}
+}
+
+// Ensure that WithDeadline does nothing when the deadline is later than the current deadline.
+func TestFakeClock_WithDeadlineLaterThanCurrent(t *testing.T) {
+	m := NewFakeClock()
+	ctx, _ := m.WithDeadline(context.Background(), m.Now().Add(time.Second))
+	ctx, _ = m.WithDeadline(ctx, m.Now().Add(10*time.Second))
+	m.Advance(time.Second)
+	select {
+	case <-ctx.Done():
+		if !errors.Is(ctx.Err(), context.DeadlineExceeded) {
+			t.Error("invalid type of error returned when deadline exceeded")
+		}
+	default:
+		t.Error("context is not cancelled when deadline exceeded")
+	}
+}
+
+// Ensure that WithDeadline cancel closes Done channel with context.Canceled error.
+func TestFakeClock_WithDeadlineCancel(t *testing.T) {
+	m := NewFakeClock()
+	ctx, cancel := m.WithDeadline(context.Background(), m.Now().Add(time.Second))
+	cancel()
+	select {
+	case <-ctx.Done():
+		if !errors.Is(ctx.Err(), context.Canceled) {
+			t.Error("invalid type of error returned after cancellation")
+		}
+	case <-time.After(time.Second):
+		t.Error("context is not cancelled after cancel was called")
+	}
+}
+
+// Ensure that WithDeadline closes child contexts after it was closed.
+func TestFakeClock_WithDeadlineCancelledWithParent(t *testing.T) {
+	m := NewFakeClock()
+	parent, cancel := context.WithCancel(context.Background())
+	ctx, _ := m.WithDeadline(parent, m.Now().Add(time.Second))
+	cancel()
+	select {
+	case <-ctx.Done():
+		if !errors.Is(ctx.Err(), context.Canceled) {
+			t.Error("invalid type of error returned after cancellation")
+		}
+	case <-time.After(time.Second):
+		t.Error("context is not cancelled when parent context is cancelled")
+	}
+}
+
+// Ensure that WithDeadline cancelled immediately when deadline has already passed.
+func TestFakeClock_WithDeadlineImmediate(t *testing.T) {
+	m := NewFakeClock()
+	ctx, _ := m.WithDeadline(context.Background(), m.Now().Add(-time.Second))
+	select {
+	case <-ctx.Done():
+		if !errors.Is(ctx.Err(), context.DeadlineExceeded) {
+			t.Error("invalid type of error returned when deadline has already passed")
+		}
+	default:
+		t.Error("context is not cancelled when deadline has already passed")
+	}
+}
+
+// Ensure that WithTimeout is cancelled when deadline exceeded.
+func TestFakeClock_WithTimeout(t *testing.T) {
+	m := NewFakeClock()
+	ctx, _ := m.WithTimeout(context.Background(), time.Second)
+	m.Advance(time.Second)
+	select {
+	case <-ctx.Done():
+		if !errors.Is(ctx.Err(), context.DeadlineExceeded) {
+			t.Error("invalid type of error returned when time is over")
+		}
+	default:
+		t.Error("context is not cancelled when time is over")
 	}
 }

--- a/timer.go
+++ b/timer.go
@@ -1,6 +1,8 @@
 package clockwork
 
-import "time"
+import (
+	"time"
+)
 
 // Timer provides an interface which can be used instead of directly using
 // [time.Timer]. The real-time timer t provides events through t.C which becomes
@@ -40,6 +42,7 @@ func (f *fakeTimer) Stop() bool {
 
 func (f *fakeTimer) expire(now time.Time) *time.Duration {
 	if f.afterFunc != nil {
+		defer gosched()
 		go f.afterFunc()
 		return nil
 	}
@@ -51,3 +54,6 @@ func (f *fakeTimer) expire(now time.Time) *time.Duration {
 	}
 	return nil
 }
+
+// Sleep momentarily so that other goroutines can process.
+func gosched() { time.Sleep(time.Millisecond) }


### PR DESCRIPTION
Hey folks.

I started using the library and found a missing piece that is very helpful for my case.
We use both time related functions and context.Timeout, but we want to be able to orchestrate all operations with a single time source.

I've introduced the logic that was already done by benbjohnson library https://github.com/benbjohnson/clock/blob/master/context.go

While testing context related things, I've also bumped into a problem with AfterFunc, which did not provide a guarantee of call on expiration. I've borrowed a "fix" with a time.Sleep from benbjohnson library. Without it, it is impossible to guarantee the call of the afterfunc.

I've ran tests for a few thousands times, but haven't see any issues.

Let me know if you have any concerns, or maybe you can help with a better way to fix this race.
