### PR TITLE
Add contexts that use FakeClock rather than the system time.

### DIFF
--- a/clockwork.go
+++ b/clockwork.go
@@ -192,7 +192,7 @@ func (fc *FakeClock) newTimer(d time.Duration, afterfunc func()) (*fakeTimer, ti
 	fc.l.Lock()
 	defer fc.l.Unlock()
 	fc.setExpirer(ft, d)
-	return ft, fc.time.Add(d)
+	return ft, ft.expiry()
 }
 
 // newTimerAtTime is like newTimer, but uses a time instead of a duration.

--- a/context.go
+++ b/context.go
@@ -2,13 +2,17 @@ package clockwork
 
 import (
 	"context"
+	"errors"
+	"sync"
+	"time"
 )
 
 // contextKey is private to this package so we can ensure uniqueness here. This
 // type identifies context values provided by this package.
 type contextKey string
 
-// keyClock provides a clock for injecting during tests. If absent, a real clock should be used.
+// keyClock provides a clock for injecting during tests. If absent, a real clock
+// should be used.
 var keyClock = contextKey("clock") // clockwork.Clock
 
 // AddToContext creates a derived context that references the specified clock.
@@ -21,10 +25,109 @@ func AddToContext(ctx context.Context, clock Clock) context.Context {
 	return context.WithValue(ctx, keyClock, clock)
 }
 
-// FromContext extracts a clock from the context. If not present, a real clock is returned.
+// FromContext extracts a clock from the context. If not present, a real clock
+// is returned.
 func FromContext(ctx context.Context) Clock {
 	if clock, ok := ctx.Value(keyClock).(Clock); ok {
 		return clock
 	}
 	return NewRealClock()
+}
+
+type fakeClockContext struct {
+	parent context.Context
+	clock  *FakeClock
+
+	deadline time.Time
+
+	mu   sync.Mutex
+	done chan struct{}
+	err  error
+}
+
+// WithDeadline returns a context with a deadline based on a [FakeClock].
+//
+// The returned context ignores parent cancelation if the parent was cancelled
+// with a [context.DeadlineExceeded] error. Any other error returned by the
+// parent is treated normally, cancelling the returned context.
+//
+// If the parent is cancelled with a [context.DeadlineExceeded] error, the only
+// way to then cancel the returned context is by calling the returned
+// context.CancelFunc.
+func WithDeadline(parent context.Context, clock *FakeClock, t time.Time) (context.Context, context.CancelFunc) {
+	ctx := &fakeClockContext{
+		parent: parent,
+	}
+	cancelOnce := ctx.runCancel(clock.afterTime(t))
+	return &fakeClockContext{}, cancelOnce
+}
+
+// WithTimeout returns a context with a timeout based on a [FakeClock].
+//
+// The returned context follows the same behaviors as [WithDeadline].
+func WithTimeout(parent context.Context, clock *FakeClock, d time.Duration) (context.Context, context.CancelFunc) {
+	ctx := &fakeClockContext{
+		parent: parent,
+	}
+	cancelOnce := ctx.runCancel(clock.After(d))
+	return &fakeClockContext{}, cancelOnce
+}
+
+func (c *fakeClockContext) setError(err error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.err = err
+	close(c.done)
+}
+
+func (c *fakeClockContext) Deadline() (time.Time, bool) {
+	return time.Time{}, false
+}
+
+func (c *fakeClockContext) Done() <-chan struct{} {
+	return c.done
+}
+
+func (c *fakeClockContext) Err() error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.err
+}
+
+func (c *fakeClockContext) Value(key any) any {
+	return c.parent.Value(key)
+}
+
+func (c *fakeClockContext) runCancel(clockExpCh <-chan time.Time) context.CancelFunc {
+	cancelCh := make(chan struct{})
+	result := sync.OnceFunc(func() {
+		close(cancelCh)
+	})
+
+	go func() {
+		select {
+		case <-clockExpCh:
+			c.setError(context.DeadlineExceeded)
+			return
+		case <-cancelCh:
+			c.setError(context.DeadlineExceeded)
+			return
+		case <-c.parent.Done():
+			if err := c.parent.Err(); !errors.Is(err, context.DeadlineExceeded) {
+				c.setError(err)
+				return
+			}
+		}
+
+		// The parent context has hit its deadline, but because we are using a fake
+		// clock we ignore it.
+		select {
+		case <-clockExpCh:
+			c.setError(context.DeadlineExceeded)
+		case <-cancelCh:
+			c.setError(context.DeadlineExceeded)
+		}
+	}()
+
+	return result
 }

--- a/context.go
+++ b/context.go
@@ -140,7 +140,7 @@ func (c *fakeClockContext) runCancel(ready chan struct{}) {
 			parentDone = nil // This case statement can only fire once.
 
 			if err := c.parent.Err(); !errors.Is(err, context.DeadlineExceeded) {
-				// The parent context was canceled with some error otehr than deadline
+				// The parent context was canceled with some error other than deadline
 				// exceeded, so we respect it.
 				ctxErr = err
 			}

--- a/context_test.go
+++ b/context_test.go
@@ -2,8 +2,10 @@ package clockwork
 
 import (
 	"context"
+	"errors"
 	"reflect"
 	"testing"
+	"time"
 )
 
 func TestContextOps(t *testing.T) {
@@ -18,9 +20,206 @@ func TestContextOps(t *testing.T) {
 	assertIsType(t, NewRealClock(), FromContext(ctx))
 }
 
-func assertIsType(t *testing.T, expectedType, object interface{}) {
+func assertIsType(t *testing.T, expectedType, object any) {
 	t.Helper()
 	if reflect.TypeOf(object) != reflect.TypeOf(expectedType) {
 		t.Fatalf("Object expected to be of type %v, but was %v", reflect.TypeOf(expectedType), reflect.TypeOf(object))
+	}
+}
+
+func TestWithDeadlineDone(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name string
+
+		start, deadline time.Time
+
+		action func(cancelParent, cancelChild context.CancelFunc, clock *FakeClock)
+
+		want error
+	}{
+		{
+			name:     "canceling parent cancels child",
+			start:    time.Unix(10, 0),
+			deadline: time.Unix(20, 0),
+			action: func(cancelParent, _ context.CancelFunc, _ *FakeClock) {
+				cancelParent()
+			},
+			want: context.Canceled,
+		},
+		{
+			name:     "canceling child cancels child",
+			start:    time.Unix(10, 0),
+			deadline: time.Unix(20, 0),
+			action: func(_, cancelChild context.CancelFunc, _ *FakeClock) {
+				cancelChild()
+			},
+			want: context.Canceled,
+		},
+		{
+			name:     "advancing past deadline cancels child",
+			start:    time.Unix(10, 0),
+			deadline: time.Unix(20, 0),
+			action: func(_, _ context.CancelFunc, clock *FakeClock) {
+				clock.Advance(10 * time.Second)
+			},
+			want: context.DeadlineExceeded,
+		},
+	}
+
+	// Background context for catching timeouts.
+	base, cancelBase := context.WithTimeout(context.Background(), timeout)
+	defer cancelBase()
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+
+			parent, cancelParent := context.WithCancel(base)
+			clock := NewFakeClockAt(tc.start)
+			child, cancelChild := WithDeadline(parent, clock, tc.deadline)
+
+			select {
+			case <-child.Done():
+				t.Fatalf("WithDeadline context finished early.")
+			default:
+			}
+
+			tc.action(cancelParent, cancelChild, clock)
+
+			select {
+			case <-child.Done():
+				if got := child.Err(); !errors.Is(got, tc.want) {
+					t.Errorf("WithDeadline context returned %v, want %v", got, tc.want)
+				}
+			case <-base.Done():
+				t.Errorf("WithDeadline context was never canceled.")
+			}
+		})
+	}
+}
+
+func TestWithDeadlineParentDeadlineDoesNotCancelChild(t *testing.T) {
+	t.Parallel()
+	base, cancelBase := context.WithTimeout(context.Background(), timeout)
+	defer cancelBase()
+
+	// Parent context hits deadline effectively immediately.
+	parent, cancelParent := context.WithTimeout(base, time.Nanosecond)
+	defer cancelParent()
+
+	clock := NewFakeClockAt(time.Unix(10, 0))
+	child, cancelChild := WithDeadline(parent, clock, time.Unix(20, 0))
+	defer cancelChild()
+
+	// TODO(https://github.com/jonboulle/clockwork/issues/67): The time.After()
+	// below makes the case for having a way to validate that no timers have
+	// fired, rather than waiting an arbitrary amount of time and hoping you've
+	// waiting long enough to cover any race conditions.
+	//
+	// An abandoned attempt to do this can be found in
+	// https://github.com/jonboulle/clockwork/pull/69.
+	select {
+	case <-time.After(50 * time.Millisecond): // Sleeping in tests, yuck.
+	case <-child.Done():
+		t.Errorf("WithDeadline context respected parenet deadline, returning %v, want parent deadline to be ignored.", child.Err())
+	}
+}
+
+func TestWithTimeoutDone(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name string
+
+		start   time.Time
+		timeout time.Duration
+
+		action func(cancelParent, cancelChild context.CancelFunc, clock *FakeClock)
+
+		want error
+	}{
+		{
+			name:    "canceling parent cancels child",
+			start:   time.Unix(10, 0),
+			timeout: 10 * time.Second,
+			action: func(cancelParent, _ context.CancelFunc, _ *FakeClock) {
+				cancelParent()
+			},
+			want: context.Canceled,
+		},
+		{
+			name:    "canceling child cancels child",
+			start:   time.Unix(10, 0),
+			timeout: 10 * time.Second,
+			action: func(_, cancelChild context.CancelFunc, _ *FakeClock) {
+				cancelChild()
+			},
+			want: context.Canceled,
+		},
+		{
+			name:    "advancing past deadline cancels child",
+			start:   time.Unix(10, 0),
+			timeout: 10 * time.Second,
+			action: func(_, _ context.CancelFunc, clock *FakeClock) {
+				clock.Advance(10 * time.Second)
+			},
+			want: context.DeadlineExceeded,
+		},
+	}
+
+	// Background context for catching timeouts.
+	background, cancelBase := context.WithTimeout(context.Background(), timeout)
+	defer cancelBase()
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+
+			parent, cancelParent := context.WithCancel(background)
+			clock := NewFakeClockAt(tc.start)
+			child, cancelChild := WithTimeout(parent, clock, tc.timeout)
+
+			select {
+			case <-child.Done():
+				t.Fatalf("WithTimeout context finished early.")
+			default:
+			}
+
+			tc.action(cancelParent, cancelChild, clock)
+
+			select {
+			case <-child.Done():
+				if got := child.Err(); !errors.Is(got, tc.want) {
+					t.Errorf("WithTimeout context returned %v, want %v", got, tc.want)
+				}
+			case <-background.Done():
+				t.Errorf("WithTimeout context was never canceled.")
+			}
+		})
+	}
+}
+
+func TestWithTimeoutParentTimeoutDoesNotCancelChild(t *testing.T) {
+	t.Parallel()
+	base, cancelBase := context.WithTimeout(context.Background(), timeout)
+	defer cancelBase()
+
+	// Parent context hits deadline effectively immediately.
+	parent, cancelParent := context.WithTimeout(base, time.Nanosecond)
+	defer cancelParent()
+
+	clock := NewFakeClockAt(time.Unix(10, 0))
+	child, cancelChild := WithTimeout(parent, clock, 10*time.Second)
+	defer cancelChild()
+
+	// TODO(https://github.com/jonboulle/clockwork/issues/67): The time.After()
+	// below makes the case for having a way to validate that no timers have
+	// fired, rather than waiting an arbitrary amount of time and hoping you've
+	// waiting long enough to cover any race conditions.
+	//
+	// An abandoned attempt to do this can be found in
+	// https://github.com/jonboulle/clockwork/pull/69.
+	select {
+	case <-time.After(50 * time.Millisecond): // Sleeping in tests, yuck.
+	case <-child.Done():
+		t.Errorf("WithTimeout context respected parenet deadline, returning %v, want parent deadline to be ignored.", child.Err())
 	}
 }

--- a/context_test.go
+++ b/context_test.go
@@ -156,7 +156,7 @@ func TestWithTimeoutDone(t *testing.T) {
 			want: context.Canceled,
 		},
 		{
-			name:    "advancing past deadline cancels child",
+			name:    "advancing past timeout cancels child",
 			start:   time.Unix(10, 0),
 			timeout: 10 * time.Second,
 			action: func(_, _ context.CancelFunc, clock *FakeClock) {


### PR DESCRIPTION
These contexts work similar to the standard library's context.WithTimeout and context.WithDeadline, expect they use a clockwork.FakeClock for deadline determination.

By nature, the generated contexts ignore parent cancelation if the parent's cancelation returned conext.DeadlineExceeded. However, an unfortunate but necessary nuances is that once the parent is cancelled with conext.DeadlineExceeded, future calls to cancel the parent due to otherwise normal calling of the parent's cancel function are not communicated to the child. As far as I can tell, there is no way to cleanly, reliably communicate that.

Once this occurs, and the child has ignored the parent cancellation, the only way to cancel the child is to advance its fake clock past the context's deadline or call the cancel function returned when the context was created.

Other changes that were made in support of this change or as targets of opportunity:
- newFakeTimer was made a standalone function since it needed to be used in 2 places.
- Functions with the pattern new*AtTime were introduced to ensure the FakeClock mutex is held when we need to call `time.Time.Sub(FakeClock.Now())` and pass that to a function that also needs to hold the FakeClock mutex. The common use case for this is supporting functions that take an absolute time rather than a duration.
- Use `slices.DeleteFunc` where we can.