### PR TITLE
Remove firer struct & fix ticker reset

### DIFF
--- a/ticker.go
+++ b/ticker.go
@@ -19,7 +19,12 @@ func (r realTicker) Chan() <-chan time.Time {
 }
 
 type fakeTicker struct {
-	firer
+	// The channel associated with the firer, used to send expiration times.
+	c chan time.Time
+
+	// The time when the firer expires. Only meaningful if the firer is currently
+	// one of a fakeClock's waiters.
+	exp time.Time
 
 	// reset and stop provide the implementation of the respective exported
 	// functions.
@@ -30,13 +35,27 @@ type fakeTicker struct {
 	d time.Duration
 }
 
-func (f *fakeTicker) Reset(d time.Duration) {
-	f.reset(d)
+func newFakeTicker(fc *FakeClock, d time.Duration) *fakeTicker {
+	var ft *fakeTicker
+	ft = &fakeTicker{
+		c: make(chan time.Time, 1),
+		d: d,
+		reset: func(d time.Duration) {
+			fc.l.Lock()
+			defer fc.l.Unlock()
+			ft.d = d
+			fc.setExpirer(ft, d)
+		},
+		stop: func() { fc.stop(ft) },
+	}
+	return ft
 }
 
-func (f *fakeTicker) Stop() {
-	f.stop()
-}
+func (f *fakeTicker) Chan() <-chan time.Time { return f.c }
+
+func (f *fakeTicker) Reset(d time.Duration) { f.reset(d) }
+
+func (f *fakeTicker) Stop() { f.stop() }
 
 func (f *fakeTicker) expire(now time.Time) *time.Duration {
 	// Never block on expiration.
@@ -46,3 +65,7 @@ func (f *fakeTicker) expire(now time.Time) *time.Duration {
 	}
 	return &f.d
 }
+
+func (f *fakeTicker) expiration() time.Time { return f.exp }
+
+func (f *fakeTicker) setExpiration(t time.Time) { f.exp = t }

--- a/ticker.go
+++ b/ticker.go
@@ -22,8 +22,8 @@ type fakeTicker struct {
 	// The channel associated with the firer, used to send expiration times.
 	c chan time.Time
 
-	// The time when the firer expires. Only meaningful if the firer is currently
-	// one of a fakeClock's waiters.
+	// The time when the ticker expires. Only meaningful if the ticker is currently
+	// one of a FakeClock's waiters.
 	exp time.Time
 
 	// reset and stop provide the implementation of the respective exported

--- a/timer.go
+++ b/timer.go
@@ -22,7 +22,7 @@ type fakeTimer struct {
 	c chan time.Time
 
 	// The time when the firer expires. Only meaningful if the firer is currently
-	// one of a fakeClock's waiters.
+	// one of a FakeClock's waiters.
 	exp time.Time
 
 	// reset and stop provide the implementation of the respective exported

--- a/timer.go
+++ b/timer.go
@@ -18,7 +18,12 @@ func (r realTimer) Chan() <-chan time.Time {
 }
 
 type fakeTimer struct {
-	firer
+	// The channel associated with the firer, used to send expiration times.
+	c chan time.Time
+
+	// The time when the firer expires. Only meaningful if the firer is currently
+	// one of a fakeClock's waiters.
+	exp time.Time
 
 	// reset and stop provide the implementation of the respective exported
 	// functions.
@@ -33,7 +38,7 @@ type fakeTimer struct {
 func newFakeTimer(fc *FakeClock, afterfunc func()) *fakeTimer {
 	var ft *fakeTimer
 	ft = &fakeTimer{
-		firer: newFirer(),
+		c: make(chan time.Time, 1),
 		reset: func(d time.Duration) bool {
 			fc.l.Lock()
 			defer fc.l.Unlock()
@@ -49,13 +54,11 @@ func newFakeTimer(fc *FakeClock, afterfunc func()) *fakeTimer {
 	return ft
 }
 
-func (f *fakeTimer) Reset(d time.Duration) bool {
-	return f.reset(d)
-}
+func (f *fakeTimer) Chan() <-chan time.Time { return f.c }
 
-func (f *fakeTimer) Stop() bool {
-	return f.stop()
-}
+func (f *fakeTimer) Reset(d time.Duration) bool { return f.reset(d) }
+
+func (f *fakeTimer) Stop() bool { return f.stop() }
 
 func (f *fakeTimer) expire(now time.Time) *time.Duration {
 	if f.afterFunc != nil {
@@ -70,3 +73,7 @@ func (f *fakeTimer) expire(now time.Time) *time.Duration {
 	}
 	return nil
 }
+
+func (f *fakeTimer) expiration() time.Time { return f.exp }
+
+func (f *fakeTimer) setExpiration(t time.Time) { f.exp = t }


### PR DESCRIPTION
This removes the firer struct and implements expirer directly by timer and ticker.

It also fixes an issue where ticker resets were not storing the new ticker duration. This would manifest as a ticker whose time was reset, but only for 1 tick, after which it would revert to the original time.